### PR TITLE
Adding Badges to README & Using pylint-django and coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@
       - yarn install
       script:           # Script to test your build
       - ./node_modules/.bin/eslint src
-      - yarn test --coverage --watchAll=false
+      - yarn test --coverage --watchAll=false | coveralls
+
     - language: python
       cache:
         pip: true
@@ -30,3 +31,5 @@
       - pylint --rcfile=./backend/.pylintrc backend --disable='fixme, duplicate-code'
       - coverage run --source='.' ./backend/manage.py test
       - coverage report --fail-under=90
+      after_success:
+      - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
       - yarn install
       script:           # Script to test your build
       - ./node_modules/.bin/eslint src
-      - yarn test --coverage --watchAll=false | coveralls
+      - yarn test --coverage --watchAll=false --coverageReporters=text-lcov | coveralls
 
     - language: python
       cache:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# swpp2019-team3
+# PapersFeed [![Build Status](https://travis-ci.com/swsnu/swpp2019-team3.svg?branch=master)](https://travis-ci.com/swsnu/swpp2019-team3) [![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2019-team3/badge.svg?branch=master)](https://coveralls.io/github/swsnu/swpp2019-team3?branch=master)

--- a/backend/.pylintrc
+++ b/backend/.pylintrc
@@ -28,7 +28,7 @@ limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_django
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "^4.3.1",
     "connected-react-router": "^6.5.2",
     "core-util-is": "^1.0.2",
+    "coveralls": "^3.0.7",
     "history": "^4.10.1",
     "react": "^16.10.1",
     "react-bootstrap": "^1.0.0-beta.14",
@@ -60,7 +61,6 @@
       "src/**/*.{js,jsx}",
       "!src/index.js",
       "!src/serviceWorker.js",
-
       "!src/store/store.js",
       "!src/store/actions/ActionTypes.js",
       "!src/store/reducers/index.js"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3032,6 +3032,18 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+coveralls@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.7.tgz#1eca48e47976e9573d6a2f18b97c2fea4026f34a"
+  integrity sha512-mUuH2MFOYB2oBaA4D4Ykqi9LaEYpMMlsiOMJOrv358yAjP6enPIk55fod2fNJ8AvwoYXStWQls37rA+s5e7boA==
+  dependencies:
+    growl "~> 1.10.0"
+    js-yaml "^3.13.1"
+    lcov-parse "^0.0.10"
+    log-driver "^1.2.7"
+    minimist "^1.2.0"
+    request "^2.86.0"
+
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -4825,6 +4837,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
   integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
+"growl@~> 1.10.0":
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -6434,6 +6451,11 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+lcov-parse@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
+  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -6569,6 +6591,11 @@ lodash.uniq@^4.5.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+log-driver@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
+  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 loglevel@^1.4.1:
   version "1.6.3"
@@ -9174,7 +9201,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.0:
+request@^2.86.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Django==2.2.5
 isort==4.3.21
 mccabe==0.6.1
 pylint==2.3.1
+pylint-django==2.0.11
 pytz==2019.2
 six==1.12.0
 sqlparse==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ wrapt==1.11.2
 mysqlclient==1.4.4
 django-mysql==3.2.0
 coverage==4.5.4
+coveralls==1.8.2


### PR DESCRIPTION
Related Issue: #24 
This PR will resolve #24 issue.

# Minor change
- I installed coveralls for python and javascript, and modified .travis.yml to send info to [Coveralls](https://coveralls.io/github/swsnu/swpp2019-team3) after building and testing.
- Also, I installed pylint-django, because doing homework 3, I found pylint generates some annoying warning like `'Class '~~~' has no 'objects' member (no-member)'` because it doesn't understand Django. Because our Travis CI doesn't allow codes with pylint warnings, I make pylint use the plugin before it makes a trouble.

- Most importantly, I edited README.md so that it includes badges about build status(from Travis CI) and test coverage(from Coveralls). After this PR is merged, its header will look like below. You can click the badges!
# PapersFeed [![Build Status](https://travis-ci.com/swsnu/swpp2019-team3.svg?branch=master)](https://travis-ci.com/swsnu/swpp2019-team3) [![Coverage Status](https://coveralls.io/repos/github/swsnu/swpp2019-team3/badge.svg?branch=master)](https://coveralls.io/github/swsnu/swpp2019-team3?branch=master)
