### PR TITLE
status_code changed

### DIFF
--- a/backend/papersfeed/constants.py
+++ b/backend/papersfeed/constants.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 # Api Error Code
-AUTH_ERROR = 207  # 인증 오류, 권한 없음 혹은 비밀번호 오류
-PARAMETER_ERROR = 208  # 필수 파라미터 에러
-NOT_AVAILABLE_API = 209  # 지원하지 않는 API 버전
-INVALID_SESSION = 210  # 잘못된 세션
-NOT_EXIST_OBJECT = 211  # 존재하지 않는 Object
-USERNAME_ALREADY_EXISTS = 216  # 이미 존재하는 사용자 이름
-EMAIL_ALREADY_EXISTS = 217  # 이미 존재하는 이메일
+AUTH_ERROR = 403  # 인증 오류, 권한 없음 혹은 비밀번호 오류
+PARAMETER_ERROR = 400  # 필수 파라미터 에러
+NOT_AVAILABLE_API = 405  # 지원하지 않는 API 버전
+INVALID_SESSION = 440  # 잘못된 세션
+NOT_EXIST_OBJECT = 404  # 존재하지 않는 Object
+USERNAME_ALREADY_EXISTS = 419  # 이미 존재하는 사용자 이름
+EMAIL_ALREADY_EXISTS = 420  # 이미 존재하는 이메일
 
 
 # Common

--- a/backend/papersfeed/tests/tests.py
+++ b/backend/papersfeed/tests/tests.py
@@ -33,4 +33,4 @@ class ApiEntryTestCase(TestCase):
                                }),
                                content_type='application/json')
 
-        self.assertEqual(response.status_code, 207)
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
Related issue: #42 
This PR resolves #42 issue.


# Major changes
AUTH_ERROR = 207  # 인증 오류, 권한 없음 혹은 비밀번호 오류
PARAMETER_ERROR = 208  # 필수 파라미터 에러
NOT_AVAILABLE_API = 209  # 지원하지 않는 API 버전
INVALID_SESSION = 210  # 잘못된 세션
NOT_EXIST_OBJECT = 211  # 존재하지 않는 Object
USERNAME_ALREADY_EXISTS = 216  # 이미 존재하는 사용자 이름
EMAIL_ALREADY_EXISTS = 217  # 이미 존재하는 이메일

changed to

AUTH_ERROR = 403  # 인증 오류, 권한 없음 혹은 비밀번호 오류
PARAMETER_ERROR = 400  # 필수 파라미터 에러
NOT_AVAILABLE_API = 405  # 지원하지 않는 API 버전
INVALID_SESSION = 440  # 잘못된 세션
NOT_EXIST_OBJECT = 404  # 존재하지 않는 Object
USERNAME_ALREADY_EXISTS = 419  # 이미 존재하는 사용자 이름
EMAIL_ALREADY_EXISTS = 420  # 이미 존재하는 이메일
