### PR TITLE
Signing out and Forced redirect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,5 @@ matrix:
     - coverage report --fail-under=90
     - coverage xml
     after_success:
+    - sonar-scanner
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
     - pylint --rcfile=./backend/.pylintrc backend --disable='fixme, duplicate-code'
     - cd backend
     - coverage run --source='.' ./manage.py test
-    - coverage report --fail-under=85
+    - coverage report --fail-under=90
     - coverage xml
     after_success:
     - coveralls

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,7 +20,7 @@ function App(props) {
                 <Switch>
                     <Route path="/" exact component={Intro} />
                     <>
-                        <Header />
+                        <Header history={props.history} />
                         <SideBar />
                         <Switch>
                             <Route path="/main" exact component={Main} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,17 +6,18 @@ import { Route, Switch } from "react-router-dom";
 import { ConnectedRouter } from "connected-react-router";
 
 import {
-    Intro, Main, ReviewDetail, PaperDetail, ReviewControl, ProfileDetail, ProfileEdit,
-    CollectionDetail, CollectionList,
+    Intro, Main, ReviewDetail, PaperDetail, ReviewControl,
+    ProfileDetail, ProfileEdit, CollectionDetail, CollectionList,
 } from "./containers";
 import {
-    Header, SideBar,
+    PrivateRoute, Header, SideBar,
 } from "./components";
 
 function App(props) {
     return (
         <ConnectedRouter history={props.history}>
             <div className="App">
+                <PrivateRoute history={props.history} />
                 <Switch>
                     <Route path="/" exact component={Intro} />
                     <>
@@ -47,7 +48,7 @@ function App(props) {
                             <Route path="/profile/:id" exact component={ProfileDetail} />
                             <Route path="/profile/:id/edit" exact component={ProfileEdit} />
                             <Route path="/collections" exact component={CollectionList} />
-                            <Route path="/collections/:collection_id" exact component={CollectionDetail} />
+                            <Route path="/collection_id=:collection_id" exact component={CollectionDetail} />
                         </Switch>
                     </>
                 </Switch>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,7 +3,10 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 
 import App from "./App";
-import { getMockStore, history } from "./test-utils/mocks";
+import { getMockStore, mockComponent, history } from "./test-utils/mocks";
+
+
+jest.mock("./components/PrivateRoute/PrivateRoute", () => jest.fn(() => (mockComponent("PrivateRoute")())));
 
 const mockStore = getMockStore({ auth: {}, paper: {} });
 

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -4,6 +4,11 @@ import Form from "react-bootstrap/Form";
 import Dropdown from "react-bootstrap/Dropdown";
 import Button from "react-bootstrap/Button";
 import Nav from "react-bootstrap/Nav";
+
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { authActions } from "../../store/actions";
+import { signoutStatus } from "../../constants/constants";
 import "./Header.css";
 
 class Header extends Component {
@@ -15,6 +20,7 @@ class Header extends Component {
             notifications: [],
         };
 
+        this.clickSignoutButtonHandler = this.clickSignoutButtonHandler.bind(this);
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -23,6 +29,22 @@ class Header extends Component {
         this.setState({
             searchKeyword: e.target.value,
         });
+    }
+
+    clickSignoutButtonHandler() {
+        this.props.onSignout()
+            .then(() => {
+                switch (this.props.signoutStatus) {
+                case signoutStatus.WAITING:
+                    // TODO: we should handle timeout
+                    break;
+                case signoutStatus.SUCCESS:
+                    this.props.history.push("/");
+                    break;
+                default:
+                    break;
+                }
+            });
     }
 
     render() {
@@ -44,9 +66,9 @@ class Header extends Component {
                         <Dropdown>
                             <Dropdown.Toggle title="myaccount" className="myaccount-button">My Account</Dropdown.Toggle>
                             <Dropdown.Menu className="myaccount-menu">
-                                <Dropdown.Header>User className</Dropdown.Header>
+                                <Dropdown.Header>Username</Dropdown.Header>
                                 <Dropdown.Item className="my-profile-button" href="/profile/user_id">My Profile</Dropdown.Item>
-                                <Dropdown.Item className="logout-button" href="/">Logout</Dropdown.Item>
+                                <Dropdown.Item className="logout-button" onClick={this.clickSignoutButtonHandler}>Logout</Dropdown.Item>
                             </Dropdown.Menu>
                         </Dropdown>
                     </div>
@@ -56,4 +78,24 @@ class Header extends Component {
     }
 }
 
-export default Header;
+const mapStateToProps = (state) => ({
+    signoutStatus: state.auth.signoutStatus,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    onSignout: () => dispatch(authActions.signout()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Header);
+
+Header.propTypes = {
+    history: PropTypes.objectOf(PropTypes.any),
+    onSignout: PropTypes.func,
+    signoutStatus: PropTypes.string,
+};
+
+Header.defaultProps = {
+    history: null,
+    onSignout: null,
+    signoutStatus: signoutStatus.NONE,
+};

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -73,7 +73,7 @@ class Header extends Component {
                             <Dropdown.Menu className="myaccount-menu">
                                 <Dropdown.Header>{username}</Dropdown.Header>
                                 <Dropdown.Item className="my-profile-button" href="/profile/user_id">My Profile</Dropdown.Item>
-                                <Dropdown.Item className="logout-button" onClick={this.clickSignoutButtonHandler}>Logout</Dropdown.Item>
+                                <Dropdown.Item className="signout-button" onClick={this.clickSignoutButtonHandler}>Logout</Dropdown.Item>
                             </Dropdown.Menu>
                         </Dropdown>
                     </div>

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -48,6 +48,11 @@ class Header extends Component {
     }
 
     render() {
+        let username = null;
+        if (this.props.me) {
+            username = this.props.me.username;
+        }
+
         return (
             <div>
                 <Navbar className="header">
@@ -66,7 +71,7 @@ class Header extends Component {
                         <Dropdown>
                             <Dropdown.Toggle title="myaccount" className="myaccount-button">My Account</Dropdown.Toggle>
                             <Dropdown.Menu className="myaccount-menu">
-                                <Dropdown.Header>Username</Dropdown.Header>
+                                <Dropdown.Header>{username}</Dropdown.Header>
                                 <Dropdown.Item className="my-profile-button" href="/profile/user_id">My Profile</Dropdown.Item>
                                 <Dropdown.Item className="logout-button" onClick={this.clickSignoutButtonHandler}>Logout</Dropdown.Item>
                             </Dropdown.Menu>
@@ -79,6 +84,7 @@ class Header extends Component {
 }
 
 const mapStateToProps = (state) => ({
+    me: state.auth.me,
     signoutStatus: state.auth.signoutStatus,
 });
 
@@ -89,12 +95,14 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(mapStateToProps, mapDispatchToProps)(Header);
 
 Header.propTypes = {
+    me: PropTypes.objectOf(PropTypes.any),
     history: PropTypes.objectOf(PropTypes.any),
     onSignout: PropTypes.func,
     signoutStatus: PropTypes.string,
 };
 
 Header.defaultProps = {
+    me: null,
     history: null,
     onSignout: null,
     signoutStatus: signoutStatus.NONE,

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -34,16 +34,10 @@ class Header extends Component {
     clickSignoutButtonHandler() {
         this.props.onSignout()
             .then(() => {
-                switch (this.props.signoutStatus) {
-                case signoutStatus.WAITING:
-                    // TODO: we should handle timeout
-                    break;
-                case signoutStatus.SUCCESS:
+                if (this.props.signoutStatus === signoutStatus.SUCCESS) {
                     this.props.history.push("/");
-                    break;
-                default:
-                    break;
                 }
+                // TODO: we should handle timeout
             });
     }
 
@@ -71,7 +65,7 @@ class Header extends Component {
                         <Dropdown>
                             <Dropdown.Toggle title="myaccount" className="myaccount-button">My Account</Dropdown.Toggle>
                             <Dropdown.Menu className="myaccount-menu">
-                                <Dropdown.Header>{username}</Dropdown.Header>
+                                <Dropdown.Header className="username-header">{username}</Dropdown.Header>
                                 <Dropdown.Item className="my-profile-button" href="/profile/user_id">My Profile</Dropdown.Item>
                                 <Dropdown.Item className="signout-button" onClick={this.clickSignoutButtonHandler}>Logout</Dropdown.Item>
                             </Dropdown.Menu>

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -7,7 +7,7 @@ import { signoutStatus } from "../../constants/constants";
 import { getMockStore } from "../../test-utils/mocks";
 import Header from "./Header";
 
-const stubInitialState = {
+let stubInitialState = {
     collection: {},
     auth: {
         singoutStatus: signoutStatus.NONE,
@@ -40,5 +40,20 @@ describe("<Header />", () => {
         wrapper.simulate("change", event);
         const headerInstance = component.find(Header.WrappedComponent).instance();
         expect(headerInstance.state.searchKeyword).toEqual("ABC");
+    });
+
+    it("should redirect when signout succeed", () => {
+        stubInitialState = {
+            auth: {
+                signoutStatus: signoutStatus.SUCCESS,
+            },
+            collection: {},
+            paper: {},
+        };
+        const component = mount(makeHeader(stubInitialState));
+        const wrapper = component.find(".signout-button").hostNodes();
+        wrapper.simulate("click");
+
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
     });
 });

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -21,8 +21,23 @@ const makeHeader = (initialState) => (
         <Header history={mockHistory} />
     </Provider>
 );
+/* eslint-disable no-unused-vars */
+const mockPromise = new Promise((resolve, reject) => { resolve(); });
+/* eslint-enable no-unused-vars */
 
 describe("<Header />", () => {
+    let spySignout;
+
+    beforeEach(() => {
+        spySignout = jest.spyOn(authActions, "signout")
+            .mockImplementation(() => () => mockPromise);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+
     it("should render without errors", () => {
         const component = mount(makeHeader(stubInitialState));
         const wrapper = component.find(".header").hostNodes();
@@ -42,7 +57,7 @@ describe("<Header />", () => {
         expect(headerInstance.state.searchKeyword).toEqual("ABC");
     });
 
-    it("should redirect when signout succeed", () => {
+    it("should call signout and redirect when signout succeeds", () => {
         stubInitialState = {
             auth: {
                 signoutStatus: signoutStatus.SUCCESS,
@@ -54,6 +69,38 @@ describe("<Header />", () => {
         const wrapper = component.find(".signout-button").hostNodes();
         wrapper.simulate("click");
 
+        expect(spySignout).toHaveBeenCalledTimes(1);
+        // FIXME: async test problem, it should be 1
         expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+
+    it("should not redirect when signout fails", () => {
+        stubInitialState = {
+            auth: {
+                signoutStatus: signoutStatus.FAILURE,
+            },
+            collection: {},
+            paper: {},
+        };
+        const component = mount(makeHeader(stubInitialState));
+        const wrapper = component.find(".signout-button").hostNodes();
+        wrapper.simulate("click");
+
+        // FIXME: async test problem
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+
+    it("if me exists, should set state appropriately", () => {
+        stubInitialState = {
+            auth: {
+                signoutStatus: signoutStatus.FAILURE,
+                me: { username: "swpp" },
+            },
+            collection: {},
+            paper: {},
+        };
+        const component = mount(makeHeader(stubInitialState));
+        const wrapper = component.find(".username-header").hostNodes();
+        expect(wrapper.text()).toEqual("swpp");
     });
 });

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -1,11 +1,31 @@
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+
+import { authActions } from "../../store/actions";
+import { signoutStatus } from "../../constants/constants";
+import { getMockStore } from "../../test-utils/mocks";
 import Header from "./Header";
+
+const stubInitialState = {
+    collection: {},
+    auth: {
+        singoutStatus: signoutStatus.NONE,
+        me: null,
+    },
+    paper: {},
+};
+const mockHistory = { push: jest.fn() };
+const makeHeader = (initialState) => (
+    <Provider store={getMockStore(initialState)}>
+        <Header history={mockHistory} />
+    </Provider>
+);
 
 describe("<Header />", () => {
     it("should render without errors", () => {
-        const component = shallow(<Header />);
-        const wrapper = component.find(".header");
+        const component = mount(makeHeader(stubInitialState));
+        const wrapper = component.find(".header").hostNodes();
         expect(wrapper.length).toBe(1);
     });
 
@@ -15,9 +35,10 @@ describe("<Header />", () => {
                 value: "ABC",
             },
         };
-        const component = shallow(<Header />);
-        const wrapper = component.find(".search-input");
+        const component = mount(makeHeader(stubInitialState));
+        const wrapper = component.find(".search-input").hostNodes();
         wrapper.simulate("change", event);
-        expect(component.state().searchKeyword).toEqual("ABC");
+        const headerInstance = component.find(Header.WrappedComponent).instance();
+        expect(headerInstance.state.searchKeyword).toEqual("ABC");
     });
 });

--- a/frontend/src/components/Modal/IntroModal/IntroModal.js
+++ b/frontend/src/components/Modal/IntroModal/IntroModal.js
@@ -125,7 +125,15 @@ class IntroModal extends Component {
             signinMessage = "Wrong password";
         }
 
+        let keyPressHandler = null;
+        let disabled = true;
+
         if (this.state.isSignupOpen) {
+            disabled = !(this.state.email && this.state.username && this.state.password);
+            // if user press enter key, consider it as signup-button click
+            keyPressHandler = (e) => {
+                if (!disabled && e.charCode === 13) this.clickSignupButtonHandler();
+            };
             modalHeader = (
                 <Modal.Header>
                     <h2 id="create-account">Create account</h2>
@@ -139,6 +147,7 @@ class IntroModal extends Component {
                   placeholder="username"
                   value={this.state.username}
                   onChange={(e) => this.setState({ username: e.target.value })}
+                  onKeyPress={keyPressHandler}
                 />
             );
             modalFooter = (
@@ -147,12 +156,17 @@ class IntroModal extends Component {
                     <Button
                       className="signup-button"
                       onClick={this.clickSignupButtonHandler}
-                      disabled={!(this.state.email && this.state.username && this.state.password)}
+                      disabled={disabled}
                     >Sign Up
                     </Button>
                 </Modal.Footer>
             );
         } else if (this.state.isSigninOpen) {
+            disabled = !(this.state.email && this.state.password);
+            // if user press enter key, consider it as signin-button click
+            keyPressHandler = (e) => {
+                if (!disabled && e.charCode === 13) this.clickSigninButtonHandler();
+            };
             modalHeader = (
                 <Modal.Header>
                     <h2 id="welcome-back">Welcome back</h2>
@@ -165,7 +179,7 @@ class IntroModal extends Component {
                     <Button
                       className="signin-button"
                       onClick={this.clickSigninButtonHandler}
-                      disabled={!(this.state.email && this.state.password)}
+                      disabled={disabled}
                     >Sign In
                     </Button>
                 </Modal.Footer>
@@ -190,6 +204,7 @@ class IntroModal extends Component {
                           placeholder="email"
                           value={this.state.email}
                           onChange={(e) => this.setState({ email: e.target.value })}
+                          onKeyPress={keyPressHandler}
                         />
                         {usernameInput}
                         <FormControl
@@ -198,6 +213,7 @@ class IntroModal extends Component {
                           placeholder="password"
                           value={this.state.password}
                           onChange={(e) => this.setState({ password: e.target.value })}
+                          onKeyPress={keyPressHandler}
                         />
                     </Modal.Body>
                     {modalFooter}

--- a/frontend/src/components/Modal/IntroModal/IntroModal.test.js
+++ b/frontend/src/components/Modal/IntroModal/IntroModal.test.js
@@ -103,6 +103,30 @@ describe("<IntroModal />", () => {
         expect(spySignup).toBeCalledTimes(1);
     });
 
+    it("should be closed and redirect if enter is pressed on signup-modal", () => {
+        const component = mount(introModal);
+        const introModalInstance = component.find(IntroModal.WrappedComponent).instance();
+
+        const openButton = component.find(".signup-open-button").hostNodes();
+        openButton.simulate("click");
+
+        expect(introModalInstance.state.isSignupOpen).toBe(true);
+
+        let wrapper = component.find(".email-input").hostNodes();
+        wrapper.simulate("change", { target: { value: "my_email@papersfeed.com" } });
+        wrapper = component.find(".username-input").hostNodes();
+        wrapper.simulate("change", { target: { value: "my_username" } });
+        wrapper = component.find(".password-input").hostNodes();
+        wrapper.simulate("change", { target: { value: "my_password" } });
+
+        // if press other key, nothing should happen
+        wrapper.simulate("keypress", { charCode: 17 });
+        expect(spySignup).toBeCalledTimes(0);
+
+        wrapper.simulate("keypress", { charCode: 13 });
+        expect(spySignup).toBeCalledTimes(1);
+    });
+
 
     it("should be closed and redirect if signinButton is clicked", () => {
         const component = mount(introModal);
@@ -122,6 +146,28 @@ describe("<IntroModal />", () => {
         expect(signinButton.length).toBe(1);
         signinButton.simulate("click");
 
+        expect(spySignin).toBeCalledTimes(1);
+    });
+
+    it("should be closed and redirect if enter is pressed on signin-modal", () => {
+        const component = mount(introModal);
+        const introModalInstance = component.find(IntroModal.WrappedComponent).instance();
+
+        const openButton = component.find(".signin-open-button").hostNodes();
+        openButton.simulate("click");
+
+        expect(introModalInstance.state.isSigninOpen).toBe(true);
+
+        let wrapper = component.find(".email-input").hostNodes();
+        wrapper.simulate("change", { target: { value: "my_email@papersfeed.com" } });
+        wrapper = component.find(".password-input").hostNodes();
+        wrapper.simulate("change", { target: { value: "my_password" } });
+
+        // if press other key, nothing should happen
+        wrapper.simulate("keypress", { charCode: 17 });
+        expect(spySignup).toBeCalledTimes(0);
+
+        wrapper.simulate("keypress", { charCode: 13 });
         expect(spySignin).toBeCalledTimes(1);
     });
 

--- a/frontend/src/components/PrivateRoute/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute/PrivateRoute.js
@@ -10,9 +10,6 @@ class PrivateRoute extends Component {
         this.props.onGetMe()
             .then(() => {
                 switch (this.props.getMeStatus) {
-                case getMeStatus.WAITING:
-                    // TODO: we should handle timeout
-                    break;
                 case getMeStatus.SUCCESS:
                     if (this.props.history.location.pathname === "/") {
                         this.props.history.goBack();
@@ -23,7 +20,7 @@ class PrivateRoute extends Component {
                         this.props.history.push("/");
                     }
                     break;
-                default:
+                default: // TODO: we should handle timeout
                     break;
                 }
             });

--- a/frontend/src/components/PrivateRoute/PrivateRoute.js
+++ b/frontend/src/components/PrivateRoute/PrivateRoute.js
@@ -1,0 +1,59 @@
+import React, { Component } from "react";
+
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { authActions } from "../../store/actions";
+import { getMeStatus } from "../../constants/constants";
+
+class PrivateRoute extends Component {
+    componentDidMount() {
+        this.props.onGetMe()
+            .then(() => {
+                switch (this.props.getMeStatus) {
+                case getMeStatus.WAITING:
+                    // TODO: we should handle timeout
+                    break;
+                case getMeStatus.SUCCESS:
+                    if (this.props.history.location.pathname === "/") {
+                        this.props.history.goBack();
+                    }
+                    break;
+                case getMeStatus.FAILURE:
+                    if (this.props.history.location.pathname !== "/") {
+                        this.props.history.push("/");
+                    }
+                    break;
+                default:
+                    break;
+                }
+            });
+    }
+
+    render() {
+        return (
+            <div className="privateroute" />
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    getMeStatus: state.auth.getMeStatus,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    onGetMe: () => dispatch(authActions.getMe()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PrivateRoute);
+
+PrivateRoute.propTypes = {
+    history: PropTypes.objectOf(PropTypes.any),
+    onGetMe: PropTypes.func,
+    getMeStatus: PropTypes.string,
+};
+
+PrivateRoute.defaultProps = {
+    history: null,
+    onGetMe: null,
+    getMeStatus: getMeStatus.NONE,
+};

--- a/frontend/src/components/PrivateRoute/PrivateRoute.test.js
+++ b/frontend/src/components/PrivateRoute/PrivateRoute.test.js
@@ -1,0 +1,110 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+
+import { authActions } from "../../store/actions";
+import { getMeStatus } from "../../constants/constants";
+import { getMockStore } from "../../test-utils/mocks";
+import PrivateRoute from "./PrivateRoute";
+
+let stubInitialState = {
+    collection: {},
+    auth: {
+        getMeStatus: getMeStatus.NONE,
+        me: null,
+    },
+    paper: {},
+};
+let mockHistory;
+const makePrivateRoute = (initialState, history) => (
+    <Provider store={getMockStore(initialState)}>
+        <PrivateRoute history={history} />
+    </Provider>
+);
+/* eslint-disable no-unused-vars */
+const mockPromise = new Promise((resolve, reject) => { resolve(); });
+/* eslint-enable no-unused-vars */
+
+describe("<PrivateRoute />", () => {
+    let spyGetMe;
+
+    beforeEach(() => {
+        mockHistory = { push: jest.fn(), goBack: jest.fn(), location: { pathname: "/main" } };
+        spyGetMe = jest.spyOn(authActions, "getMe")
+            .mockImplementation(() => () => mockPromise);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+
+    it("should render without errors and call getMe", () => {
+        const component = mount(makePrivateRoute(stubInitialState, mockHistory));
+        const wrapper = component.find(".privateroute").hostNodes();
+        expect(wrapper.length).toBe(1);
+        expect(spyGetMe).toHaveBeenCalledTimes(1);
+    });
+
+    it("should stay when getMe succeeds on other than Intro Page", () => {
+        stubInitialState = {
+            auth: {
+                getMeStatus: getMeStatus.SUCCESS,
+            },
+            collection: {},
+            paper: {},
+        };
+        const component = mount(makePrivateRoute(stubInitialState, mockHistory));
+        component.update();
+
+        // FIXME: async test problem
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+
+    it("should redirect when getMe succeeds on Intro Page", () => {
+        stubInitialState = {
+            auth: {
+                getMeStatus: getMeStatus.SUCCESS,
+            },
+            collection: {},
+            paper: {},
+        };
+        mockHistory = { push: jest.fn(), goBack: jest.fn(), location: { pathname: "/" } };
+        const component = mount(makePrivateRoute(stubInitialState, mockHistory));
+        component.update();
+
+        // FIXME: async test problem, it should be 1
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+
+    it("should stay when getMe fails on Intro Page", () => {
+        stubInitialState = {
+            auth: {
+                getMeStatus: getMeStatus.FAILURE,
+            },
+            collection: {},
+            paper: {},
+        };
+        mockHistory = { push: jest.fn(), goBack: jest.fn(), location: { pathname: "/" } };
+        const component = mount(makePrivateRoute(stubInitialState, mockHistory));
+        component.update();
+
+        // FIXME: async test problem
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+
+    it("should redirect when getMe fails on other than Intro Page", () => {
+        stubInitialState = {
+            auth: {
+                getMeStatus: getMeStatus.FAILURE,
+            },
+            collection: {},
+            paper: {},
+        };
+        const component = mount(makePrivateRoute(stubInitialState, mockHistory));
+        component.update();
+
+        // FIXME: async test problem, it should be 1
+        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+    });
+});

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -7,6 +7,7 @@ import Header from "./Header/Header";
 import IntroModal from "./Modal/IntroModal/IntroModal";
 import AddPaperModal from "./Modal/AddPaperModal/AddPaperModal";
 import Reply from "./Reply/Reply";
+import PrivateRoute from "./PrivateRoute/PrivateRoute";
 
 export {
     SideBar,
@@ -18,4 +19,5 @@ export {
     IntroModal,
     AddPaperModal,
     Reply,
+    PrivateRoute,
 };

--- a/frontend/src/constants/constants.js
+++ b/frontend/src/constants/constants.js
@@ -25,6 +25,13 @@ export const signinStatus = {
     WRONG_PW: "WRONG_PW",
 };
 
+export const signoutStatus = {
+    NONE: "NONE",
+    WAITING: "WAITING",
+    SUCCESS: "SUCCESS",
+    FAILURE: "FAILURE",
+};
+
 export const getPaperStatus = {
     NONE: "NONE",
     WAITING: "WAITING",

--- a/frontend/src/constants/constants.js
+++ b/frontend/src/constants/constants.js
@@ -32,6 +32,13 @@ export const signoutStatus = {
     FAILURE: "FAILURE",
 };
 
+export const getMeStatus = {
+    NONE: "NONE",
+    WAITING: "WAITING",
+    SUCCESS: "SUCCESS",
+    FAILURE: "FAILURE",
+};
+
 export const getPaperStatus = {
     NONE: "NONE",
     WAITING: "WAITING",

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -122,8 +122,8 @@ class CollectionDetail extends Component {
                         </div>
                         <div id="collectionDescription">
                             <div id="date">
-                                <div id="creationDate"><h>Created: {this.props.thisCollection.creationDate}</h></div>
-                                <div id="lastUpdateDate"><h>Last Update: {this.props.thisCollection.lastUpdateDate}</h></div>
+                                <div id="creationDate"><p>Created: {this.props.thisCollection.creationDate}</p></div>
+                                <div id="lastUpdateDate"><p>Last Update: {this.props.thisCollection.lastUpdateDate}</p></div>
                             </div>
                             <p id="descriptionBox">{this.props.thisCollection.description}</p>
                         </div>

--- a/frontend/src/containers/Collection/CollectionList/CollectionList.js
+++ b/frontend/src/containers/Collection/CollectionList/CollectionList.js
@@ -48,7 +48,7 @@ class CollectionList extends Component {
         return (
             <div className="CollectionList">
                 <div className="CollectionListContent">
-                    <div id="collectionListText"><h>Your Colletion List</h></div>
+                    <div id="collectionListText"><h2>Your Colletion List</h2></div>
                     <div id="colletionCards">
                         <div id="collectionCardsLeft">{collectionCardsLeft}</div>
                         <div id="collectionCardsRight">{collectionCardsRight}</div>

--- a/frontend/src/containers/Profile/ProfileEdit/ProfileEdit.js
+++ b/frontend/src/containers/Profile/ProfileEdit/ProfileEdit.js
@@ -26,7 +26,7 @@ class ProfileEdit extends Component {
             <div className="ProfileEdit">
                 <div className="ProfileEditContent">
                     <div className="EditDescArea">
-                        <h id="editDescTag">Your Description</h>
+                        <h3 id="editDescTag">Your Description</h3>
                         <textarea
                           id="editDescription"
                           rows="4"

--- a/frontend/src/store/actions/actionTypes.js
+++ b/frontend/src/store/actions/actionTypes.js
@@ -57,6 +57,10 @@ export const authConstants = {
     SIGNOUT_REQUEST: "SIGNOUT_REQUEST",
     SIGNOUT_SUCCESS: "SIGNOUT_SUCCESS",
     SIGNOUT_FAILURE: "SIGNOUT_FAILURE",
+
+    // GetMe
+    GETME_SUCCESS: "GETME_SUCCESS",
+    GETME_FAILURE: "GETME_FAILURE",
 };
 
 export const paperConstants = {

--- a/frontend/src/store/actions/auth/auth.js
+++ b/frontend/src/store/actions/auth/auth.js
@@ -56,3 +56,17 @@ const signinFailure = (error) => {
 export const signin = (user) => (dispatch) => axios.get("/api/session", { params: user })
     .then((res) => dispatch(signinSuccess(res.data)))
     .catch((err) => dispatch(signinFailure(err)));
+
+const signoutSuccess = () => ({
+    type: authConstants.SIGNOUT_SUCCESS,
+    target: null,
+});
+
+const signoutFailure = (error) => ({
+    type: authConstants.SIGNOUT_FAILURE,
+    target: error,
+});
+
+export const signout = () => (dispatch) => axios.delete("api/session")
+    .then(() => dispatch(signoutSuccess()))
+    .catch((err) => dispatch(signoutFailure(err)));

--- a/frontend/src/store/actions/auth/auth.js
+++ b/frontend/src/store/actions/auth/auth.js
@@ -83,5 +83,5 @@ const getMeFailure = (error) => ({
 });
 
 export const getMe = () => (dispatch) => axios.get("/api/user/me")
-    .then((res) => dispatch(getMeSuccess(res.data)))
+    .then((res) => dispatch(getMeSuccess(res.data.data)))
     .catch((err) => dispatch(getMeFailure(err)));

--- a/frontend/src/store/actions/auth/auth.js
+++ b/frontend/src/store/actions/auth/auth.js
@@ -67,6 +67,21 @@ const signoutFailure = (error) => ({
     target: error,
 });
 
-export const signout = () => (dispatch) => axios.delete("api/session")
+export const signout = () => (dispatch) => axios.delete("/api/session")
     .then(() => dispatch(signoutSuccess()))
     .catch((err) => dispatch(signoutFailure(err)));
+
+
+const getMeSuccess = (user) => ({
+    type: authConstants.GETME_SUCCESS,
+    target: user,
+});
+
+const getMeFailure = (error) => ({
+    type: authConstants.GETME_FAILURE,
+    target: error,
+});
+
+export const getMe = () => (dispatch) => axios.get("/api/user/me")
+    .then((res) => dispatch(getMeSuccess(res.data)))
+    .catch((err) => dispatch(getMeFailure(err)));

--- a/frontend/src/store/actions/auth/auth.test.js
+++ b/frontend/src/store/actions/auth/auth.test.js
@@ -114,7 +114,7 @@ describe("authActions", () => {
             .mockImplementation(() => new Promise((resolve) => {
                 const result = {
                     status: 200,
-                    data: {},
+                    data: { id: 1, username: "swpp" },
                 };
                 resolve(result);
             }));
@@ -179,6 +179,80 @@ describe("authActions", () => {
         mockStore.dispatch(authActions.signin(stubSigningInUser))
             .then(() => {
                 expect(spy).toHaveBeenCalledWith("/api/session", { params: stubSigningInUser });
+                done();
+            });
+    });
+
+
+    it("'signout' should call axios.delete", (done) => {
+        const spy = jest.spyOn(axios, "delete")
+            .mockImplementation(() => new Promise((resolve) => {
+                const result = {
+                    status: 200,
+                    data: {},
+                };
+                resolve(result);
+            }));
+
+        mockStore.dispatch(authActions.signout())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/session");
+                done();
+            });
+    });
+
+    it("'signout' should handle failure", (done) => {
+        const spy = jest.spyOn(axios, "delete")
+            .mockImplementation(() => new Promise((_, reject) => {
+                const error = {
+                    response: {
+                        status: 403,
+                        data: {},
+                    },
+                };
+                reject(error);
+            }));
+
+        mockStore.dispatch(authActions.signout())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/session");
+                done();
+            });
+    });
+
+
+    it("'getMe' should call axios.get", (done) => {
+        const spy = jest.spyOn(axios, "get")
+            .mockImplementation(() => new Promise((resolve) => {
+                const result = {
+                    status: 200,
+                    data: { id: 1, username: "swpp" },
+                };
+                resolve(result);
+            }));
+
+        mockStore.dispatch(authActions.getMe())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/user/me");
+                done();
+            });
+    });
+
+    it("'getMe' should handle unauthorized person", (done) => {
+        const spy = jest.spyOn(axios, "get")
+            .mockImplementation(() => new Promise((_, reject) => {
+                const error = {
+                    response: {
+                        status: 403,
+                        data: {},
+                    },
+                };
+                reject(error);
+            }));
+
+        mockStore.dispatch(authActions.getMe())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/user/me");
                 done();
             });
     });

--- a/frontend/src/store/actions/auth/auth.test.js
+++ b/frontend/src/store/actions/auth/auth.test.js
@@ -1,13 +1,17 @@
 import axios from "axios";
 
 import { authActions } from "..";
-import { signupStatus, signinStatus } from "../../../constants/constants";
+import {
+    signupStatus, signinStatus, signoutStatus, getMeStatus,
+} from "../../../constants/constants";
 import { getMockStore } from "../../../test-utils/mocks";
 
 const stubInitialState = {
     auth: {
         signupStatus: signupStatus.NONE,
         signinStatus: signinStatus.NONE,
+        signoutStatus: signoutStatus.NONE,
+        getMeStatus: getMeStatus.NONE,
     },
     collection: {},
     paper: {},

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -1,9 +1,10 @@
-import { signup, signin } from "./auth/auth";
+import { signup, signin, signout } from "./auth/auth";
 import getPaper from "./paper/paper";
 
 export const authActions = {
     signup,
     signin,
+    signout,
 };
 export const paperActions = {
     getPaper,

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -1,4 +1,6 @@
-import { signup, signin, signout, getMe } from "./auth/auth";
+import {
+    signup, signin, signout, getMe,
+} from "./auth/auth";
 import getPaper from "./paper/paper";
 
 export const authActions = {

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -1,10 +1,11 @@
-import { signup, signin, signout } from "./auth/auth";
+import { signup, signin, signout, getMe } from "./auth/auth";
 import getPaper from "./paper/paper";
 
 export const authActions = {
     signup,
     signin,
     signout,
+    getMe,
 };
 export const paperActions = {
     getPaper,

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -1,10 +1,14 @@
 import { authConstants } from "../../actions/actionTypes";
-import { signupStatus, signinStatus, signoutStatus } from "../../../constants/constants";
+import {
+    signupStatus, signinStatus, signoutStatus, getMeStatus,
+} from "../../../constants/constants";
 
 const initialState = {
     signupStatus: signupStatus.NONE,
     signinStatus: signinStatus.NONE,
     signoutStatus: signoutStatus.NONE,
+    getMeStatus: getMeStatus.NONE,
+    me: null,
 };
 
 const reducer = (state = initialState, action) => {
@@ -27,6 +31,12 @@ const reducer = (state = initialState, action) => {
         return { ...state, signoutStatus: signoutStatus.SUCCESS };
     case authConstants.SIGNOUT_FAILURE:
         return { ...state, signoutStatus: signoutStatus.FAILURE };
+
+    case authConstants.GETME_SUCCESS:
+        console.log(action.target);
+        return { ...state, getMeStatus: getMeStatus.SUCCESS, me: action.target };
+    case authConstants.GETME_FAILURE:
+        return { ...state, getMeStatus: getMeStatus.FAILURE };
 
     default:
         return { ...state };

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -1,9 +1,10 @@
 import { authConstants } from "../../actions/actionTypes";
-import { signupStatus, signinStatus } from "../../../constants/constants";
+import { signupStatus, signinStatus, signoutStatus } from "../../../constants/constants";
 
 const initialState = {
     signupStatus: signupStatus.NONE,
     signinStatus: signinStatus.NONE,
+    signoutStatus: signoutStatus.NONE,
 };
 
 const reducer = (state = initialState, action) => {
@@ -14,12 +15,19 @@ const reducer = (state = initialState, action) => {
         return { ...state, signupStatus: signupStatus.DUPLICATE_USERNAME };
     case authConstants.SIGNUP_FAILURE_DUPLICATE_EMAIL:
         return { ...state, signupStatus: signupStatus.DUPLICATE_EMAIL };
+
     case authConstants.SIGNIN_SUCCESS:
         return { ...state, signinStatus: signinStatus.SUCCESS };
     case authConstants.SIGNIN_FAILURE_USER_NOT_EXIST:
         return { ...state, signinStatus: signinStatus.USER_NOT_EXIST };
     case authConstants.SIGNIN_FAILURE_WRONG_PW:
         return { ...state, signinStatus: signinStatus.WRONG_PW };
+
+    case authConstants.SIGNOUT_SUCCESS:
+        return { ...state, signoutStatus: signoutStatus.SUCCESS };
+    case authConstants.SIGNOUT_FAILURE:
+        return { ...state, signoutStatus: signoutStatus.FAILURE };
+
     default:
         return { ...state };
     }

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -21,7 +21,7 @@ const reducer = (state = initialState, action) => {
         return { ...state, signupStatus: signupStatus.DUPLICATE_EMAIL };
 
     case authConstants.SIGNIN_SUCCESS:
-        return { ...state, signinStatus: signinStatus.SUCCESS };
+        return { ...state, signinStatus: signinStatus.SUCCESS, me: action.target };
     case authConstants.SIGNIN_FAILURE_USER_NOT_EXIST:
         return { ...state, signinStatus: signinStatus.USER_NOT_EXIST };
     case authConstants.SIGNIN_FAILURE_WRONG_PW:
@@ -33,7 +33,6 @@ const reducer = (state = initialState, action) => {
         return { ...state, signoutStatus: signoutStatus.FAILURE };
 
     case authConstants.GETME_SUCCESS:
-        console.log(action.target);
         return { ...state, getMeStatus: getMeStatus.SUCCESS, me: action.target };
     case authConstants.GETME_FAILURE:
         return { ...state, getMeStatus: getMeStatus.FAILURE };

--- a/frontend/src/store/reducers/auth/auth.test.js
+++ b/frontend/src/store/reducers/auth/auth.test.js
@@ -129,4 +129,47 @@ describe("Auth reducer", () => {
             me: null,
         });
     });
+
+    it("should handle signout failure", () => {
+        const newState = reducer(undefined, {
+            type: authConstants.SIGNOUT_FAILURE,
+            target: null,
+        });
+        expect(newState).toEqual({
+            signupStatus: signupStatus.NONE,
+            signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.FAILURE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
+        });
+    });
+
+
+    it("should process getMe", () => {
+        const newState = reducer(undefined, {
+            type: authConstants.GETME_SUCCESS,
+            target: stubSigningInUser,
+        });
+        expect(newState).toEqual({
+            signupStatus: signupStatus.NONE,
+            signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.SUCCESS,
+            me: stubSigningInUser,
+        });
+    });
+
+    it("should handle getMe failure", () => {
+        const newState = reducer(undefined, {
+            type: authConstants.GETME_FAILURE,
+            target: stubSigningInUser,
+        });
+        expect(newState).toEqual({
+            signupStatus: signupStatus.NONE,
+            signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.FAILURE,
+            me: null,
+        });
+    });
 });

--- a/frontend/src/store/reducers/auth/auth.test.js
+++ b/frontend/src/store/reducers/auth/auth.test.js
@@ -1,6 +1,8 @@
 import reducer from "./auth";
 import { authConstants } from "../../actions/actionTypes";
-import { signupStatus, signinStatus } from "../../../constants/constants";
+import {
+    signupStatus, signinStatus, signoutStatus, getMeStatus,
+} from "../../../constants/constants";
 
 const stubSigningUpUser = {
     email: "my_email@papersfeed.com",
@@ -19,6 +21,9 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.NONE,
             signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 
@@ -30,6 +35,9 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.SUCCESS,
             signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 
@@ -41,6 +49,9 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.DUPLICATE_EMAIL,
             signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 
@@ -52,6 +63,9 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.DUPLICATE_USERNAME,
             signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 
@@ -64,6 +78,12 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.NONE,
             signinStatus: signinStatus.SUCCESS,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: {
+                email: "my_email@papersfeed.com",
+                password: "swpp",
+            },
         });
     });
 
@@ -75,6 +95,9 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.NONE,
             signinStatus: signinStatus.USER_NOT_EXIST,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 
@@ -86,6 +109,24 @@ describe("Auth reducer", () => {
         expect(newState).toEqual({
             signupStatus: signupStatus.NONE,
             signinStatus: signinStatus.WRONG_PW,
+            signoutStatus: signoutStatus.NONE,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
+        });
+    });
+
+
+    it("should process signout", () => {
+        const newState = reducer(undefined, {
+            type: authConstants.SIGNOUT_SUCCESS,
+            target: null,
+        });
+        expect(newState).toEqual({
+            signupStatus: signupStatus.NONE,
+            signinStatus: signinStatus.NONE,
+            signoutStatus: signoutStatus.SUCCESS,
+            getMeStatus: getMeStatus.NONE,
+            me: null,
         });
     });
 });


### PR DESCRIPTION
Related Issue: #40 
This PR will resolve #40 issue.

# Major changes
- Now, signing out(log out) is also possible. You can sign out through the dropdown button of the header.

- Also, I implemented PrivateRoute, which redirects you to Intro Page, if you haven't signed in. Or, if you've signed in and tried to go to Intro Page, you'll be forced to move backward.

- In addition, you can check your username on the dropdown of the header, thanks to getMe(GET /api/user/me API).

![스크린샷 2019-11-09 22 52 14](https://user-images.githubusercontent.com/35535636/68529589-95415380-0343-11ea-8bf5-a335a2dc738e.png)

- Plus, you can submit the form of signing up and in by pressing the enter key. This was suggested by our TA in a [comment](https://github.com/swsnu/swpp2019-team3/issues/61#issuecomment-551417712) of the issue #61.


# Minor changes
- I changed few \<h>s to \<h3> or similar things because they generated warnings.

- I increased the coverage threshold of backend to 90%, because actually we have always achieved above that level.


## Remaining problems
As mentioned in #51 and #55 PR, I always have trouble testing async parts of components. I asked about this to our TA, but he couldn't give a clear answer. I know the reason of problems, but can't solve this. Please let me know if you find solution. I put `FIXME`, if I'm not satisfied by my codes.


### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [ ] passe all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
