### PR TITLE
csrf_setting

### DIFF
--- a/backend/PapersFeed_backend/settings.py
+++ b/backend/PapersFeed_backend/settings.py
@@ -128,3 +128,6 @@ STATIC_URL = '/static/'
 # Session
 SESSION_COOKIE_AGE = 60 * 30
 SESSION_SAVE_EVERY_REQUEST = True
+
+# CSRF
+CSRF_COOKIE_NAME = 'csrftoken'

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -40,6 +40,34 @@ class UserTestCase(TestCase):
                     }),
                     content_type='application/json')
 
+    def test_csrf(self):
+        # By default, csrf checks are disabled in test client
+        # To test csrf protection we enforce csrf checks here
+        client = Client(enforce_csrf_checks=True)
+        response = client.post('/api/user',
+                               json.dumps({
+                                   constants.EMAIL: 'csrf@snu.ac.kr',
+                                   constants.USERNAME: 'scrf',
+                                   constants.PASSWORD: 'iluvswpp1234'
+                               }),
+                               content_type='application/json')
+        self.assertEqual(response.status_code, 403)  # Request without csrf token returns 403 response
+
+        response = client.get('/api/token')
+
+        csrf_token = response.cookies['csrftoken'].value  # Get csrf token from cookie
+
+        response = client.post('/api/user',
+                               json.dumps({
+                                   constants.EMAIL: 'csrf@snu.ac.kr',
+                                   constants.USERNAME: 'csrf',
+                                   constants.PASSWORD: 'iluvswpp1234'
+                               }),
+                               content_type='application/json',
+                               HTTP_X_CSRFTOKEN=csrf_token)
+
+        self.assertEqual(response.status_code, 200)  # Pass csrf protection
+
     def test_sign_up(self):
         """ SIGN UP """
         client = Client()

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -41,6 +41,7 @@ class UserTestCase(TestCase):
                     content_type='application/json')
 
     def test_csrf(self):
+        """ CSRF TOKEN TEST """
         # By default, csrf checks are disabled in test client
         # To test csrf protection we enforce csrf checks here
         client = Client(enforce_csrf_checks=True)

--- a/backend/papersfeed/urls.py
+++ b/backend/papersfeed/urls.py
@@ -3,9 +3,11 @@
 # pylint: skip-file
 
 from django.conf.urls import url
+from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('token', views.token, name='token'),
     url(r'^(?P<api>\w+)$', views.api_entry, name='api_entry'),
     url(r'^(?P<api>\w+)/(?P<second_api>\w+)$', views.api_entry, name='api_entry'),
     url(r'^(?P<api>\w+)/(?P<second_api>\w+)/(?P<third_api>\w+)$', views.api_entry, name='api_entry'),

--- a/backend/papersfeed/views.py
+++ b/backend/papersfeed/views.py
@@ -24,10 +24,11 @@ def api_not_found():
 
 @ensure_csrf_cookie
 def token(request):
+    """token"""
     if request.method == 'GET':
         return HttpResponse(status=204)
-    else:
-        return HttpResponseNotAllowed(['GET'])
+
+    return HttpResponseNotAllowed(['GET'])
 
 
 @ensure_csrf_cookie

--- a/backend/papersfeed/views.py
+++ b/backend/papersfeed/views.py
@@ -6,8 +6,9 @@ import json
 import traceback
 
 # Django Modules
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse, HttpResponseNotAllowed
 from django.core.exceptions import ObjectDoesNotExist
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.csrf import csrf_exempt
 
 # Internal Modules
@@ -20,6 +21,14 @@ from . import constants
 def api_not_found():
     """api_not_found"""
     raise ApiError(404)
+
+
+@ensure_csrf_cookie
+def token(request):
+    if request.method == 'GET':
+        return HttpResponse(status=204)
+    else:
+        return HttpResponseNotAllowed(['GET'])
 
 
 @csrf_exempt

--- a/backend/papersfeed/views.py
+++ b/backend/papersfeed/views.py
@@ -31,7 +31,7 @@ def token(request):
     return HttpResponseNotAllowed(['GET'])
 
 
-@ensure_csrf_cookie
+# @ensure_csrf_cookie
 def api_entry(request, api, second_api=None, third_api=None, fourth_api=None):
     """api_entry"""
     # API 요청에 Return 할 Response Initialize

--- a/backend/papersfeed/views.py
+++ b/backend/papersfeed/views.py
@@ -9,7 +9,6 @@ import traceback
 from django.http import JsonResponse, HttpResponse, HttpResponseNotAllowed
 from django.core.exceptions import ObjectDoesNotExist
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django.views.decorators.csrf import csrf_exempt
 
 # Internal Modules
 from papersfeed.utils.base_utils import ApiError
@@ -31,7 +30,7 @@ def token(request):
         return HttpResponseNotAllowed(['GET'])
 
 
-@csrf_exempt
+@ensure_csrf_cookie
 def api_entry(request, api, second_api=None, third_api=None, fourth_api=None):
     """api_entry"""
     # API 요청에 Return 할 Response Initialize

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import { Provider } from "react-redux";
+import axios from "axios";
 
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
@@ -16,6 +17,9 @@ ReactDOM.render(
     </Provider>,
     document.getElementById("root"),
 );
+
+axios.defaults.xsrfHeaderName = "X-CSRFTOKEN";
+axios.defaults.xsrfCookieName = "csrftoken";
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
Related Issue: #83 
It resolves #83 



# Major changes
/api/token API를 HW3와 동일하게 그대로 가져와 추가.
views.py api_entry()의 decorator로 @csrf_exempt 가 아닌 @ensure_csrf_cookie로 수정.

setting.py에서
CSRF_COOKIE_NAME = 'csrftoken' 

index.js에서 axios default setting
axios.defaults.xsrfHeaderName = "X-CSRFTOKEN";
axios.defaults.xsrfCookieName = "csrftoken";

참고
https://vsupalov.com/avoid-csrf-errors-axios-django/
https://docs.djangoproject.com/en/2.2/ref/csrf/

# Minor changes
tests_user.py에 test_csrf()를 추가하여
csrf token이 없을 시 403, token이 있는 경우, 200이 뜨는 테스트 추가




### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] passe all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
