### PR TITLE
Pagination 적용

### DIFF
--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -120,7 +120,10 @@ def delete_review(args):
 
 def get_review_paper(args):
     """Get Review Paper"""
-    return {constants.REVIEWS: reviews_utils.select_review_paper(args)}
+    reviews, page_number, is_finished = reviews_utils.select_review_paper(args)
+    return {constants.REVIEWS: reviews,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_review_user(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -155,7 +155,10 @@ def delete_like_paper(args):
 
 def get_paper_like(args):
     """Get Paper Like"""
-    return {constants.PAPERS: papers_utils.select_paper_like(args)}
+    papers, page_number, is_finished = papers_utils.select_paper_like(args)
+    return {constants.PAPERS: papers,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_like_review(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -125,7 +125,10 @@ def get_review_paper(args):
 
 def get_review_user(args):
     """Get Review User"""
-    return {constants.REVIEWS: reviews_utils.select_review_user(args)}
+    reviews, page_number, is_finished = reviews_utils.select_review_user(args)
+    return {constants.REVIEWS: reviews,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_paper_search(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -140,7 +140,10 @@ def get_collection_search(args):
 
 def get_user_search(args):
     """Get User Search"""
-    return {constants.USERS: users_utils.select_user_search(args)}
+    users, page_number, is_finished = users_utils.select_user_search(args)
+    return {constants.USERS: users,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_like_paper(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -260,7 +260,10 @@ def delete_user_collection(args):
 
 def get_notification(args):
     """Get Notification"""
-    return {constants.NOTIFICATIONS: notification_utils.select_notifications(args)}
+    notifications, page_number, is_finished = notification_utils.select_notifications(args)
+    return {constants.NOTIFICATIONS: notifications,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def put_notification(args):
@@ -270,9 +273,15 @@ def put_notification(args):
 
 def get_user_following(args):
     """Get Users User is Following"""
-    return {constants.USERS: users_utils.select_user_following(args)}
+    users, page_number, is_finished = users_utils.select_user_following(args)
+    return {constants.USERS: users,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_user_followed(args):
     """Get User’s Followers"""
-    return {constants.USERS: users_utils.select_user_followed(args)}
+    users, page_number, is_finished = users_utils.select_user_followed(args)
+    return {constants.USERS: users,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -130,7 +130,10 @@ def get_review_user(args):
 
 def get_paper_search(args):
     """Get Paper Search"""
-    return {constants.PAPERS: papers_utils.select_paper_search(args)}
+    papers, page_number, is_finished = papers_utils.select_paper_search(args)
+    return {constants.PAPERS: papers,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_collection_search(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -200,7 +200,10 @@ def delete_like_reply(args):
 
 def get_reply_collection(args):
     """Get reply collection"""
-    return {constants.REPLIES: replies_utils.select_reply_collection(args)}
+    replies, page_number, is_finished = replies_utils.select_reply_collection(args)
+    return {constants.REPLIES: replies,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_reply_collection(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -90,7 +90,10 @@ def get_paper(args):
 
 def get_paper_collection(args):
     """Get Paper Collection"""
-    return {constants.PAPERS: papers_utils.select_paper_collection(args)}
+    papers, page_number, is_finished = papers_utils.select_paper_collection(args)
+    return {constants.PAPERS: papers,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def put_paper_collection(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -135,7 +135,10 @@ def get_paper_search(args):
 
 def get_collection_search(args):
     """Get Collection Search"""
-    return {constants.COLLECTIONS: collections_utils.select_collection_search(args)}
+    collections, page_number, is_finished = collections_utils.select_collection_search(args)
+    return {constants.COLLECTIONS: collections,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_user_search(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -240,7 +240,10 @@ def delete_reply_review(args):
 
 def get_user_collection(args):
     """Get User Collection"""
-    return {constants.USERS: users_utils.select_user_collection(args)}
+    users, page_number, is_finished = users_utils.select_user_collection(args)
+    return {constants.USERS: users,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_user_collection(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -80,7 +80,10 @@ def delete_collection(args):
 
 def get_collection_user(args):
     """Get Collection User"""
-    return {constants.COLLECTIONS: collections_utils.select_collection_user(args)}
+    collections, page_number, is_finished = collections_utils.select_collection_user(args)
+    return {constants.COLLECTIONS: collections,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def get_paper(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -185,7 +185,10 @@ def delete_like_collection(args):
 
 def get_collection_like(args):
     """Get Collection Like"""
-    return {constants.COLLECTIONS: collections_utils.select_collection_like(args)}
+    collections, page_number, is_finished = collections_utils.select_collection_like(args)
+    return {constants.COLLECTIONS: collections,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_like_reply(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -170,7 +170,10 @@ def delete_like_review(args):
 
 def get_review_like(args):
     """Get Review Like"""
-    return {constants.REVIEWS: reviews_utils.select_review_like(args)}
+    reviews, page_number, is_finished = reviews_utils.select_review_like(args)
+    return {constants.REVIEWS: reviews,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_like_collection(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -220,7 +220,10 @@ def delete_reply_collection(args):
 
 def get_reply_review(args):
     """Get reply review"""
-    return {constants.REPLIES: replies_utils.select_reply_review(args)}
+    replies, page_number, is_finished = replies_utils.select_reply_review(args)
+    return {constants.REPLIES: replies,
+            constants.PAGE_NUMBER: page_number,
+            constants.IS_FINISHED: is_finished}
 
 
 def post_reply_review(args):

--- a/backend/papersfeed/constants.py
+++ b/backend/papersfeed/constants.py
@@ -25,6 +25,7 @@ LIKED = 'liked'
 LIKES = 'likes'
 TYPE = 'type'
 PAGE_NUMBER = 'page_number'
+IS_FINISHED = 'is_finished'
 
 # User
 USER = 'user'

--- a/backend/papersfeed/constants.py
+++ b/backend/papersfeed/constants.py
@@ -24,6 +24,7 @@ REQUEST = 'request'
 LIKED = 'liked'
 LIKES = 'likes'
 TYPE = 'type'
+PAGE_NUMBER = 'page_number'
 
 # User
 USER = 'user'

--- a/backend/papersfeed/tests/papers/tests_paper.py
+++ b/backend/papersfeed/tests/papers/tests_paper.py
@@ -262,6 +262,8 @@ class PaperTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(len(json.loads(response.content.decode())[constants.PAPERS]), 2)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'AI'
         response = client.get('/api/paper/search',
@@ -272,6 +274,8 @@ class PaperTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(len(json.loads(response.content.decode())[constants.PAPERS]), 1)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'Computer'
         response = client.get('/api/paper/search',
@@ -282,6 +286,8 @@ class PaperTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         self.assertEqual(len(json.loads(response.content.decode())[constants.PAPERS]), 1)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     @patch('requests.post')
     @patch('requests.get')
@@ -345,6 +351,8 @@ class PaperTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         # there was one result from arXiv, so our search API's response should have one paper result, too
         self.assertEqual(len(json.loads(response.content.decode())[constants.PAPERS]), 1)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
 # pylint: disable=too-few-public-methods
 class MockResponse:

--- a/backend/papersfeed/tests/papers/tests_paper.py
+++ b/backend/papersfeed/tests/papers/tests_paper.py
@@ -116,6 +116,8 @@ class PaperTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_put_paper_collection(self):
         """ PUT PAPER TO COLLECTION OR REMOVE PAPRE FROM COLLECTION"""
@@ -141,6 +143,7 @@ class PaperTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+
 
     def test_paper_like(self):
         """ PAPER LIKE """

--- a/backend/papersfeed/tests/papers/tests_paper.py
+++ b/backend/papersfeed/tests/papers/tests_paper.py
@@ -199,6 +199,8 @@ class PaperTestCase(TestCase):
         # Get Papers the user liked
         response = client.get('/api/paper/like')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         papers = json.loads(response.content)['papers']
         self.assertEqual(len(papers), 3)

--- a/backend/papersfeed/tests/tests.py
+++ b/backend/papersfeed/tests/tests.py
@@ -47,7 +47,7 @@ class ApiEntryTestCase(TestCase):
 
         self.assertEqual(response.status_code, 520)
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals, too-many-statements
     def test_pagination(self):
         """pagination should return isFinished value correctly, and current page number"""
         client = Client()
@@ -171,16 +171,16 @@ class ApiEntryTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp6_user_id)
         UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp7_user_id)
 
+        # Test without page_number it should be 1 by default
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp_user_id,
-                                  constants.PAGE_NUMBER: 1
+                                  constants.ID: swpp_user_id
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 6)
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
-        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         swpp8_user_id = User.objects.filter(email='swpp8@snu.ac.kr').first().id
         swpp9_user_id = User.objects.filter(email='swpp9@snu.ac.kr').first().id
@@ -202,7 +202,7 @@ class ApiEntryTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 10)
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], False)
-        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         response = client.get('/api/user/following',
                               data={
@@ -213,5 +213,5 @@ class ApiEntryTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 1)
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
-        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '2')
-    # pylint: enable=too-many-locals
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 2)
+    # pylint: enable=too-many-locals, too-many-statements

--- a/backend/papersfeed/tests/tests.py
+++ b/backend/papersfeed/tests/tests.py
@@ -47,6 +47,7 @@ class ApiEntryTestCase(TestCase):
 
         self.assertEqual(response.status_code, 520)
 
+    # pylint: disable=too-many-locals
     def test_pagination(self):
         """pagination should return isFinished value correctly, and current page number"""
         client = Client()
@@ -178,6 +179,8 @@ class ApiEntryTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 6)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
 
         swpp8_user_id = User.objects.filter(email='swpp8@snu.ac.kr').first().id
         swpp9_user_id = User.objects.filter(email='swpp9@snu.ac.kr').first().id
@@ -198,6 +201,8 @@ class ApiEntryTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 10)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], False)
+        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
 
         response = client.get('/api/user/following',
                               data={
@@ -207,3 +212,6 @@ class ApiEntryTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 1)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '2')
+    # pylint: enable=too-many-locals

--- a/backend/papersfeed/tests/tests.py
+++ b/backend/papersfeed/tests/tests.py
@@ -3,7 +3,8 @@ import json
 
 from django.test import TestCase, Client
 from papersfeed import constants
-
+from papersfeed.models.users.user import User
+from papersfeed.models.users.user_follow import UserFollow
 
 class ApiEntryTestCase(TestCase):
     """api_entry test"""
@@ -45,3 +46,164 @@ class ApiEntryTestCase(TestCase):
                                content_type='application/json')
 
         self.assertEqual(response.status_code, 520)
+
+    def test_pagination(self):
+        """pagination should return isFinished value correctly, and current page number"""
+        client = Client()
+
+        # Sign Up
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp@snu.ac.kr',
+                        constants.USERNAME: 'swpp',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp2@snu.ac.kr',
+                        constants.USERNAME: 'swpp2',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp3@snu.ac.kr',
+                        constants.USERNAME: 'swpp3',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp4@snu.ac.kr',
+                        constants.USERNAME: 'swpp4',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp5@snu.ac.kr',
+                        constants.USERNAME: 'swpp5',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp6@snu.ac.kr',
+                        constants.USERNAME: 'swpp6',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp7@snu.ac.kr',
+                        constants.USERNAME: 'swpp7',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp8@snu.ac.kr',
+                        constants.USERNAME: 'swpp8',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp9@snu.ac.kr',
+                        constants.USERNAME: 'swpp9',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp10@snu.ac.kr',
+                        constants.USERNAME: 'swpp10',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp11@snu.ac.kr',
+                        constants.USERNAME: 'swpp11',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        client.post('/api/user',
+                    json.dumps({
+                        constants.EMAIL: 'swpp12@snu.ac.kr',
+                        constants.USERNAME: 'swpp12',
+                        constants.PASSWORD: 'iluvswpp1234'
+                    }),
+                    content_type='application/json')
+
+        # Sign In
+        client.get('/api/session',
+                   data={
+                       constants.EMAIL: 'swpp@snu.ac.kr',
+                       constants.PASSWORD: 'iluvswpp1234'
+                   },
+                   content_type='application/json')
+
+        swpp_user_id = User.objects.filter(email='swpp@snu.ac.kr').first().id
+        swpp2_user_id = User.objects.filter(email='swpp2@snu.ac.kr').first().id
+        swpp3_user_id = User.objects.filter(email='swpp3@snu.ac.kr').first().id
+        swpp4_user_id = User.objects.filter(email='swpp4@snu.ac.kr').first().id
+        swpp5_user_id = User.objects.filter(email='swpp5@snu.ac.kr').first().id
+        swpp6_user_id = User.objects.filter(email='swpp6@snu.ac.kr').first().id
+        swpp7_user_id = User.objects.filter(email='swpp7@snu.ac.kr').first().id
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp2_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp3_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp4_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp5_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp6_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp7_user_id)
+
+        response = client.get('/api/user/following',
+                              data={
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
+                              },
+                              content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 6)
+
+        swpp8_user_id = User.objects.filter(email='swpp8@snu.ac.kr').first().id
+        swpp9_user_id = User.objects.filter(email='swpp9@snu.ac.kr').first().id
+        swpp10_user_id = User.objects.filter(email='swpp10@snu.ac.kr').first().id
+        swpp11_user_id = User.objects.filter(email='swpp11@snu.ac.kr').first().id
+        swpp12_user_id = User.objects.filter(email='swpp12@snu.ac.kr').first().id
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp8_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp9_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp10_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp11_user_id)
+        UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp12_user_id)
+
+        response = client.get('/api/user/following',
+                              data={
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
+                              },
+                              content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 10)
+
+        response = client.get('/api/user/following',
+                              data={
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 2
+                              },
+                              content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 1)

--- a/backend/papersfeed/tests/tests_collection.py
+++ b/backend/papersfeed/tests/tests_collection.py
@@ -275,6 +275,8 @@ class CollectionTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.COLLECTIONS]), 1)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'keyword'
         response = client.get('/api/collection/search',
@@ -284,6 +286,8 @@ class CollectionTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.COLLECTIONS]), 3)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'blahblah'
         response = client.get('/api/collection/search',
@@ -293,6 +297,8 @@ class CollectionTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.COLLECTIONS]), 0)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_collection_like(self):
         """ COLLECTION LIKE """

--- a/backend/papersfeed/tests/tests_collection.py
+++ b/backend/papersfeed/tests/tests_collection.py
@@ -331,6 +331,8 @@ class CollectionTestCase(TestCase):
         # Get Collections the user liked
         response = client.get('/api/collection/like')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         collections = json.loads(response.content)['collections']
         self.assertEqual(len(collections), 2)

--- a/backend/papersfeed/tests/tests_collection.py
+++ b/backend/papersfeed/tests/tests_collection.py
@@ -133,6 +133,8 @@ class CollectionTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         collection_id = Collection.objects.filter(title='SWPP Papers').first().id
         self.assertJSONEqual(response.content, {
@@ -148,7 +150,9 @@ class CollectionTestCase(TestCase):
                     constants.LIKES: 0,
                     constants.REPLIES: 0,
                 }
-            }]
+            }],
+            constants.PAGE_NUMBER: 1,
+            constants.IS_FINISHED: True
         })
 
     def test_get_collections_of_user_with_paper(self):
@@ -174,6 +178,9 @@ class CollectionTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
+
         collection_id = Collection.objects.filter(title='SWPP Papers').first().id
         self.assertJSONEqual(response.content, {
             constants.COLLECTIONS: [{
@@ -188,7 +195,9 @@ class CollectionTestCase(TestCase):
                     constants.LIKES: 0,
                     constants.REPLIES: 0,
                 }
-            }]
+            }],
+            constants.PAGE_NUMBER: 1,
+            constants.IS_FINISHED: True
         })
 
     def test_delete_collection(self):

--- a/backend/papersfeed/tests/tests_notification.py
+++ b/backend/papersfeed/tests/tests_notification.py
@@ -131,7 +131,7 @@ class LikeTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
-        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         user2_id = User.objects.get(email='user2@snu.ac.kr').id
 

--- a/backend/papersfeed/tests/tests_notification.py
+++ b/backend/papersfeed/tests/tests_notification.py
@@ -130,6 +130,8 @@ class LikeTestCase(TestCase):
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(json.loads(response.content.decode())[constants.PAGE_NUMBER], '1')
 
         user2_id = User.objects.get(email='user2@snu.ac.kr').id
 

--- a/backend/papersfeed/tests/tests_notification.py
+++ b/backend/papersfeed/tests/tests_notification.py
@@ -124,7 +124,11 @@ class LikeTestCase(TestCase):
                    content_type='application/json')
 
         # User1 Get Notifications
-        response = client.get('/api/notification')
+        response = client.get('/api/notification',
+                              data={
+                                  constants.PAGE_NUMBER: 1
+                              },
+                              content_type='application/json')
         self.assertEqual(response.status_code, 200)
 
         user2_id = User.objects.get(email='user2@snu.ac.kr').id

--- a/backend/papersfeed/tests/tests_replies.py
+++ b/backend/papersfeed/tests/tests_replies.py
@@ -151,8 +151,12 @@ class ReplyTestCase(TestCase):
             + '"contains_paper": false, "count": {"users": 1, "papers": 0, "likes": 0, "replies": 1}},'
             + ' "user": {"id": ' + str(user_id)
             + ', "username": "swpp", "email": "swpp@snu.ac.kr", "description": "", '
-            + '"count": {"follower": 0, "following": 0}}, "count": {"likes": 0}}]}',
+            + '"count": {"follower": 0, "following": 0}}, "count": {"likes": 0}}], '
+            + '"page_number": 1, '
+            + '"is_finished": true}',
             response.content.decode())
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Get Replies Review
         response = client.get('/api/reply/review',

--- a/backend/papersfeed/tests/tests_replies.py
+++ b/backend/papersfeed/tests/tests_replies.py
@@ -162,6 +162,8 @@ class ReplyTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_edit_reply(self):
         """EDIT REPLY"""

--- a/backend/papersfeed/tests/tests_review.py
+++ b/backend/papersfeed/tests/tests_review.py
@@ -198,6 +198,8 @@ class ReviewTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_review_like(self):
         """ REVIEW LIKE """

--- a/backend/papersfeed/tests/tests_review.py
+++ b/backend/papersfeed/tests/tests_review.py
@@ -173,6 +173,8 @@ class ReviewTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_get_reviews_of_paper(self):
         """ GET PAPER'S REVIEWS """

--- a/backend/papersfeed/tests/tests_review.py
+++ b/backend/papersfeed/tests/tests_review.py
@@ -245,6 +245,8 @@ class ReviewTestCase(TestCase):
         # Get Reviews the user liked
         response = client.get('/api/review/like')
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         reviews = json.loads(response.content)['reviews']
         self.assertEqual(len(reviews), 2)

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -301,6 +301,8 @@ class UserTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 3)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'keyword'
         response = client.get('/api/user/search',
@@ -310,6 +312,8 @@ class UserTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 2)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         # Search with Keyword 'blahblah'
         response = client.get('/api/user/search',
@@ -319,6 +323,8 @@ class UserTestCase(TestCase):
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(json.loads(response.content.decode())[constants.USERS]), 0)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
     def test_get_user_following(self):
         """Get Users User is Following"""

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -486,6 +486,8 @@ class UserTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
+        self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
         users = json.loads(response.content)['users']
         self.assertEqual(len(users), 1)

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -339,7 +339,8 @@ class UserTestCase(TestCase):
         # My Following User count : 0
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -349,7 +350,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp2_user_id)
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -359,7 +361,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp3_user_id)
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -368,7 +371,8 @@ class UserTestCase(TestCase):
         # Other's Following User count : 0
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp2_user_id
+                                  constants.ID: swpp2_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -378,7 +382,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp2_user_id, followed_user_id=swpp_user_id)
         response = client.get('/api/user/following',
                               data={
-                                  constants.ID: swpp2_user_id
+                                  constants.ID: swpp2_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -403,7 +408,8 @@ class UserTestCase(TestCase):
         # My Followed User count : 0
         response = client.get('/api/user/followed',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -413,7 +419,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp2_user_id, followed_user_id=swpp_user_id)
         response = client.get('/api/user/followed',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -423,7 +430,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp3_user_id, followed_user_id=swpp_user_id)
         response = client.get('/api/user/followed',
                               data={
-                                  constants.ID: swpp_user_id
+                                  constants.ID: swpp_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -432,7 +440,8 @@ class UserTestCase(TestCase):
         # Other's Followed User count : 0
         response = client.get('/api/user/followed',
                               data={
-                                  constants.ID: swpp2_user_id
+                                  constants.ID: swpp2_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)
@@ -442,7 +451,8 @@ class UserTestCase(TestCase):
         UserFollow.objects.create(following_user_id=swpp_user_id, followed_user_id=swpp2_user_id)
         response = client.get('/api/user/followed',
                               data={
-                                  constants.ID: swpp2_user_id
+                                  constants.ID: swpp2_user_id,
+                                  constants.PAGE_NUMBER: 1
                               },
                               content_type='application/json')
         self.assertEqual(response.status_code, 200)

--- a/backend/papersfeed/utils/base_utils.py
+++ b/backend/papersfeed/utils/base_utils.py
@@ -17,26 +17,14 @@ def is_parameter_exists(requirements, args):
             raise ApiError(constants.PARAMETER_ERROR)
 
 
-def get_results_from_queryset(queryset, count):
+def get_results_from_queryset(queryset, count, page_num=0):
     """Paginate Query"""
     if count is None:
         results = queryset
     else:
-        # 20개씩 Pagenation을 하면서 찾는다
+        # 최대 20개씩 Pagination을 하면서 찾는다
         pages = Paginator(queryset, min(20, count))
 
-        results = []
-
-        for page_num in pages.page_range:
-            page = pages.page(page_num)
-
-            for element in page:
-                if len(results) >= count:
-                    break
-
-                results.append(element)
-
-            if len(results) >= count:
-                break
+        return pages.get_page(page_num)
 
     return results

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -194,13 +194,20 @@ def select_collection_search(args):
     # Search Keyword
     keyword = args[constants.TEXT]
 
-    # Filter Query
-    filter_query = Q(title__icontains=keyword) | Q(text__icontains=keyword)
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Collections Queryset
+    queryset = Collection.objects.filter(Q(title__icontains=keyword) | Q(text__icontains=keyword))\
+        .values_list('id', flat=True)
+
+    # Collection Ids
+    collection_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # Collections
-    collections, _, _ = __get_collections(filter_query, request_user, None)
+    collections, _, is_finished = __get_collections(Q(id__in=collection_ids), request_user, 10)
 
-    return collections
+    return collections, page_number, is_finished
 
 
 def select_collection_like(args):

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -166,8 +166,14 @@ def select_collection_user(args):
     # User Id
     user_id = args[constants.ID]
 
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Collections Queryset
+    queryset = CollectionUser.objects.filter(user_id=user_id).values_list('collection_id', flat=True)
+
     # User's Collections
-    collection_ids = CollectionUser.objects.filter(user_id=user_id).values_list('collection_id', flat=True)
+    collection_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # Filter Query
     filter_query = Q(id__in=collection_ids)
@@ -177,9 +183,9 @@ def select_collection_user(args):
         paper_id = args[constants.PAPER]
 
     # Collections
-    collections, _, _ = __get_collections(filter_query, request_user, None, paper_id=paper_id)
+    collections, _, is_finished = __get_collections(filter_query, request_user, 10, paper_id=paper_id)
 
-    return collections
+    return collections, page_number, is_finished
 
 
 def select_collection_search(args):

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -209,16 +209,24 @@ def select_collection_like(args):
     # Request User
     request_user = args[constants.USER]
 
-    # Collection Ids
-    collection_ids = CollectionLike.objects.filter(Q(user_id=request_user.id)).order_by(
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Collections Queryset
+
+    queryset = CollectionLike.objects.filter(Q(user_id=request_user.id)).order_by(
         '-creation_date').values_list('collection_id', flat=True)
+
+    # Collection Ids
+    collection_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # need to maintain the order
     preserved = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(collection_ids)])
 
     # Collections
-    collections, _, _ = __get_collections(Q(id__in=collection_ids), request_user, None, order_by=preserved)
-    return collections
+    collections, _, is_finished = __get_collections(Q(id__in=collection_ids), request_user, 10, order_by=preserved)
+
+    return collections, page_number, is_finished
 
 
 def update_paper_collection(args):

--- a/backend/papersfeed/utils/notifications/utils.py
+++ b/backend/papersfeed/utils/notifications/utils.py
@@ -12,16 +12,26 @@ from papersfeed.models.users.user import User
 
 def select_notifications(args):
     """Get Notifications of the current User"""
+    is_parameter_exists([
+        constants.PAGE_NUMBER
+    ], args)
 
     # Request User
     request_user = args[constants.USER] if constants.USER in args else None
 
+    # Page Number
+    page_number = args[constants.PAGE_NUMBER]
+
     # User
     user = User.objects.get(pk=request_user.id)
 
-    notifications = user.notifications.unread().filter(~Q(actor_object_id=request_user.id))
-    notifications = get_results_from_queryset(notifications, count=None)
+    # Notification QuerySet
+    queryset = user.notifications.unread().filter(~Q(actor_object_id=request_user.id))
+
+    notifications = get_results_from_queryset(queryset, 10, page_number)
+
     notifications = __pack_notifications(notifications)
+
     return notifications
 
 

--- a/backend/papersfeed/utils/notifications/utils.py
+++ b/backend/papersfeed/utils/notifications/utils.py
@@ -32,7 +32,9 @@ def select_notifications(args):
 
     notifications = __pack_notifications(notifications)
 
-    return notifications
+    is_finished = len(notifications) < 10
+
+    return notifications, page_number, is_finished
 
 
 def read_notification(args):

--- a/backend/papersfeed/utils/notifications/utils.py
+++ b/backend/papersfeed/utils/notifications/utils.py
@@ -12,15 +12,11 @@ from papersfeed.models.users.user import User
 
 def select_notifications(args):
     """Get Notifications of the current User"""
-    is_parameter_exists([
-        constants.PAGE_NUMBER
-    ], args)
-
     # Request User
     request_user = args[constants.USER] if constants.USER in args else None
 
     # Page Number
-    page_number = args[constants.PAGE_NUMBER]
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
 
     # User
     user = User.objects.get(pk=request_user.id)

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -88,12 +88,18 @@ def select_paper_search(args):
     # Search Keyword
     keyword = args[constants.TEXT]
 
-    # Paper Ids
-    paper_ids = Paper.objects.filter(Q(title__icontains=keyword) | Q(abstract__icontains=keyword)) \
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Papers Queryset
+    queryset = Paper.objects.filter(Q(title__icontains=keyword) | Q(abstract__icontains=keyword)) \
         .values_list('id', flat=True)
 
+    # Paper Ids
+    paper_ids = get_results_from_queryset(queryset, 20, page_number)
+
     # if there is no result in our DB
-    if paper_ids.count() == 0:
+    if paper_ids.object_list.count() == 0:
         # exploit arXiv
         try:
             start = 0
@@ -123,9 +129,9 @@ def select_paper_search(args):
     filter_query = Q(id__in=paper_ids)
 
     # Papers
-    papers, _, _ = __get_papers(filter_query, request_user, None)
+    papers, _, is_finished = __get_papers(filter_query, request_user, 20)
 
-    return papers
+    return papers, page_number, is_finished
 
 
 def select_paper_like(args):

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -64,16 +64,22 @@ def select_paper_collection(args):
     # Collection Id
     collection_id = args[constants.ID]
 
-    # Papers
-    collection_papers = CollectionPaper.objects.filter(
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Papers Queryset
+    queryset = CollectionPaper.objects.filter(
         collection_id=collection_id
     )
 
+    # Papers
+    collection_papers = get_results_from_queryset(queryset, 10, page_number)
+
     paper_ids = [collection_paper.paper_id for collection_paper in collection_papers]
 
-    papers, _, _ = __get_papers(Q(id__in=paper_ids), request_user, None)
+    papers, _, is_finished = __get_papers(Q(id__in=paper_ids), request_user, 10)
 
-    return papers
+    return papers, page_number, is_finished
 
 
 # pylint: disable=too-many-locals

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -134,16 +134,22 @@ def select_paper_like(args):
     # Request User
     request_user = args[constants.USER]
 
-    # Paper Ids
-    paper_ids = PaperLike.objects.filter(Q(user_id=request_user.id)).order_by(
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Papers Queryset
+    queryset = PaperLike.objects.filter(Q(user_id=request_user.id)).order_by(
         '-creation_date').values_list('paper_id', flat=True)
+
+    # Paper Ids
+    paper_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # need to maintain the order
     preserved = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(paper_ids)])
 
     # Papers
-    papers, _, _ = __get_papers(Q(id__in=paper_ids), request_user, None, preserved)
-    return papers
+    papers, _, is_finished = __get_papers(Q(id__in=paper_ids), request_user, 10, preserved)
+    return papers, page_number, is_finished
 
 
 def get_papers(filter_query, request_user, count):

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -139,7 +139,7 @@ def select_paper_search(args):
     papers, _, is_finished = __get_papers(filter_query, request_user, 20)
 
     return papers, page_number, is_finished
-# pylint: ensable=too-many-locals
+# pylint: enable=too-many-locals
 
 def select_paper_like(args):
     """Select Paper Like"""

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -76,6 +76,7 @@ def select_paper_collection(args):
     return papers
 
 
+# pylint: disable=too-many-locals
 def select_paper_search(args):
     """Select Paper Search"""
     is_parameter_exists([
@@ -132,7 +133,7 @@ def select_paper_search(args):
     papers, _, is_finished = __get_papers(filter_query, request_user, 20)
 
     return papers, page_number, is_finished
-
+# pylint: ensable=too-many-locals
 
 def select_paper_like(args):
     """Select Paper Like"""

--- a/backend/papersfeed/utils/replies/utils.py
+++ b/backend/papersfeed/utils/replies/utils.py
@@ -32,16 +32,21 @@ def select_reply_collection(args):
     # Request User
     request_user = args[constants.USER]
 
-    # Replies
-    collection_replies = ReplyCollection.objects.filter(
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Replies Queryset
+    queryset = ReplyCollection.objects.filter(
         collection_id=collection_id
     )
+    # Replies
+    collection_replies = get_results_from_queryset(queryset, 10, page_number)
 
     reply_ids = [collection_reply.reply_id for collection_reply in collection_replies]
 
-    replies, _, _ = __get_replies(Q(id__in=reply_ids), request_user, None)
+    replies, _, is_finished = __get_replies(Q(id__in=reply_ids), request_user, 10)
 
-    return replies
+    return replies, page_number, is_finished
 
 def select_reply_review(args):
     """Select reply collection"""

--- a/backend/papersfeed/utils/replies/utils.py
+++ b/backend/papersfeed/utils/replies/utils.py
@@ -55,16 +55,22 @@ def select_reply_review(args):
     # Request User
     request_user = args[constants.USER]
 
-    # Replies
-    review_replies = ReplyReview.objects.filter(
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Replies Queryset
+    queryset = ReplyReview.objects.filter(
         review_id=review_id
     )
 
+    # Replies
+    review_replies = get_results_from_queryset(queryset, 10, page_number)
+
     reply_ids = [review_reply.reply_id for review_reply in review_replies]
 
-    replies, _, _ = __get_replies(Q(id__in=reply_ids), request_user, None)
+    replies, _, is_finished = __get_replies(Q(id__in=reply_ids), request_user, 10)
 
-    return replies
+    return replies, page_number, is_finished
 
 def insert_reply_collection(args):
     """Insert Reply Collection"""

--- a/backend/papersfeed/utils/reviews/utils.py
+++ b/backend/papersfeed/utils/reviews/utils.py
@@ -182,9 +182,18 @@ def select_review_user(args):
     # Request Uer
     request_user = args[constants.USER]
 
-    reviews, _, _ = __get_reviews(Q(user_id=user_id), request_user, None)
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
 
-    return reviews
+    # Reviews Queryset
+    queryset = Review.objects.filter(Q(user_id=user_id)).values_list('id', flat=True)
+
+    # Review Ids
+    review_ids = get_results_from_queryset(queryset, 10, page_number)
+
+    reviews, _, is_finished = __get_reviews(Q(id__in=review_ids), request_user, 10)
+
+    return reviews, page_number, is_finished
 
 
 def select_review_like(args):

--- a/backend/papersfeed/utils/reviews/utils.py
+++ b/backend/papersfeed/utils/reviews/utils.py
@@ -165,9 +165,18 @@ def select_review_paper(args):
     # Request Uer
     request_user = args[constants.USER]
 
-    reviews, _, _ = __get_reviews(Q(paper_id=paper_id), request_user, None)
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
 
-    return reviews
+    # Reviews Queryset
+    queryset = Review.objects.filter(Q(paper_id=paper_id)).values_list('id', flat=True)
+
+    # Review Ids
+    review_ids = get_results_from_queryset(queryset, 10, page_number)
+
+    reviews, _, is_finished = __get_reviews(Q(id__in=review_ids), request_user, 10)
+
+    return reviews, page_number, is_finished
 
 
 def select_review_user(args):

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -247,7 +247,8 @@ def select_user_search(args):
 def select_user_following(args):
     """Select Users User is Following"""
     is_parameter_exists([
-        constants.ID
+        constants.ID,
+        constants.PAGE_NUMBER
     ], args)
 
     # Request User
@@ -256,8 +257,14 @@ def select_user_following(args):
     # Requested User ID
     requested_user_id = args[constants.ID]
 
+    # Page Number
+    page_number = args[constants.PAGE_NUMBER]
+
+    # Following QuerySet
+    queryset = UserFollow.objects.filter(following_user=requested_user_id).values_list('followed_user', flat=True)
+
     # User Ids
-    user_ids = UserFollow.objects.filter(following_user=requested_user_id).values_list('followed_user', flat=True)
+    user_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # Filter Query
     filter_query = Q(id__in=user_ids)
@@ -271,7 +278,8 @@ def select_user_following(args):
 def select_user_followed(args):
     """Select User’s Followers"""
     is_parameter_exists([
-        constants.ID
+        constants.ID,
+        constants.PAGE_NUMBER
     ], args)
 
     # Request User
@@ -280,8 +288,14 @@ def select_user_followed(args):
     # Requested User ID
     requested_user_id = args[constants.ID]
 
+    # Page Number
+    page_number = args[constants.PAGE_NUMBER]
+
+    # Follower QuerySet
+    queryset = UserFollow.objects.filter(followed_user=requested_user_id).values_list('following_user', flat=True)
+
     # User Ids
-    user_ids = UserFollow.objects.filter(followed_user=requested_user_id).values_list('following_user', flat=True)
+    user_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # Filter Query
     filter_query = Q(id__in=user_ids)

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -235,13 +235,19 @@ def select_user_search(args):
     # Search Keyword
     keyword = args[constants.TEXT]
 
-    # Filter Query
-    filter_query = Q(username__icontains=keyword)
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # User Queryset
+    queryset = User.objects.filter(Q(username__icontains=keyword)).values_list('id', flat=True)
+
+    # User Ids
+    user_ids = get_results_from_queryset(queryset, 10, page_number)
 
     # Users
-    users, _, _ = __get_users(filter_query, request_user, None)
+    users, _, is_finished = __get_users(Q(id__in=user_ids), request_user, 10)
 
-    return users
+    return users, page_number, is_finished
 
 
 def select_user_following(args):

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -247,8 +247,7 @@ def select_user_search(args):
 def select_user_following(args):
     """Select Users User is Following"""
     is_parameter_exists([
-        constants.ID,
-        constants.PAGE_NUMBER
+        constants.ID
     ], args)
 
     # Request User
@@ -258,7 +257,7 @@ def select_user_following(args):
     requested_user_id = args[constants.ID]
 
     # Page Number
-    page_number = args[constants.PAGE_NUMBER]
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
 
     # Following QuerySet
     queryset = UserFollow.objects.filter(following_user=requested_user_id).values_list('followed_user', flat=True)
@@ -278,8 +277,7 @@ def select_user_following(args):
 def select_user_followed(args):
     """Select User’s Followers"""
     is_parameter_exists([
-        constants.ID,
-        constants.PAGE_NUMBER
+        constants.ID
     ], args)
 
     # Request User
@@ -289,7 +287,7 @@ def select_user_followed(args):
     requested_user_id = args[constants.ID]
 
     # Page Number
-    page_number = args[constants.PAGE_NUMBER]
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
 
     # Follower QuerySet
     queryset = UserFollow.objects.filter(followed_user=requested_user_id).values_list('following_user', flat=True)
@@ -376,17 +374,23 @@ def select_user_collection(args):
 
     request_user = args[constants.USER]
 
+    # Page Number
+    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+
+    # Members QuerySet
+    queryset = CollectionUser.objects.filter(collection_id=collection_id)
+
     # Members(including owner) Of Collections
-    collection_members = CollectionUser.objects.filter(collection_id=collection_id)
+    collection_members = get_results_from_queryset(queryset, 10, page_number)
 
     # Member Ids
     member_ids = [collection_member.user_id for collection_member in collection_members]
     member_ids = list(set(member_ids))
 
     # Get Members
-    members, _, _ = __get_users(Q(id__in=member_ids), request_user, None)
+    members, _, is_finished = __get_users(Q(id__in=member_ids), request_user, 10)
 
-    return members
+    return members, page_number, is_finished
 
 
 def insert_user_collection(args):

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -270,9 +270,9 @@ def select_user_following(args):
     filter_query = Q(id__in=user_ids)
 
     # Users
-    users, _, _ = __get_users(filter_query, request_user, None)
+    users, _, is_finished = __get_users(filter_query, request_user, 10)
 
-    return users
+    return users, page_number, is_finished
 
 
 def select_user_followed(args):
@@ -301,9 +301,9 @@ def select_user_followed(args):
     filter_query = Q(id__in=user_ids)
 
     # Users
-    users, _, _ = __get_users(filter_query, request_user, None)
+    users, _, is_finished = __get_users(filter_query, request_user, 10)
 
-    return users
+    return users, page_number, is_finished
 
 
 def get_users(filter_query, request_user, count):


### PR DESCRIPTION
Related Issue: #115 
It resolves #115



# Major changes
### Backend

-  response에서 users를 return 한다면, is_finished, page_number는 users와 같은 hierarchy로 넘어간다.
- Paginator가 1-based page number를 사용하므로, 시작 number는 1이다.
- page_number를 안 보낼 경우, default값으로 1을 사용한다.
- 한 페이지에 10개씩 불러온다. (예외는 하단 API 목록에 기재)
- **Pagination 적용 API**

> GET /api/user/following
> GET /api/user/following
> GET /api/notifications
> GET /api/user/collection
> GET /api/reply/review
> GET /api/reply/collection
> GET /api/collection/like
> GET /api/review/like
> GET /api/paper/like
> GET /api/user/search
> GET /api/collection/search
> GET /api/paper/search - 20개씩 불러온다.
> GET /api/review/user
> GET /api/review/paper
> GET /api/paper/collection
> GET /api/collection/user

### Frontend

- Pagination 로직이 적용된 API 사용 시, page_number key 값으로 1-based page number를 보내면 해당하는 page를 보내준다.
- Race Condition(?)으로 연속된 페이지에 겹치는 object가 있다면 unique값인 id로 비교해 array에 추가하지 않는 로직이 요구된다.


# Issues
1. papers/utils.py의 select_paper_search 함수에서 too-many-locals 에러가 발생하는데,
@davin111  # exploit arXiv 하는 부분을 따로 함수로 빼는 것을 제안드립니다.
추가 작업을 하신다고하셔서 제가 코드를 수정하지 않았습니다.
그래서 일단 disable/enable 문으로 함수를 묶어두었습니다. 작업 후에 제거해주시면 될 것 같습니다!
2. GET /api/collection/user에서 optional하게 paper_id를 받아서 paper가 속해있는 collection만 골라주는 로직이 Pagination이 들어가게되면서 문제가 됩니다. 따로 API 분기를 해야합니다.(예를 들어, 첫 page에 paper가 속해있는 collection이 아무것도 없다면 첫 화면에서는 아무 collection도 뜨지 않게됩니다. 만약 100번째의 collection에 처음으로 속해있다면 view more 버튼을 10번 가까이 눌러봐야 볼 수 있는 문제가 있습니다. )





### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] passe all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
