### PR TITLE
Improvement about Collection Features & Async Tests

### DIFF
--- a/backend/PapersFeed_backend/settings.py
+++ b/backend/PapersFeed_backend/settings.py
@@ -113,13 +113,13 @@ AUTH_USER_MODEL = 'papersfeed.User'
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
-USE_I18N = True
+# USE_I18N = True
 
-USE_L10N = True
+# USE_L10N = True
 
-USE_TZ = True
+# USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)

--- a/backend/papersfeed/constants.py
+++ b/backend/papersfeed/constants.py
@@ -26,6 +26,8 @@ LIKES = 'likes'
 TYPE = 'type'
 PAGE_NUMBER = 'page_number'
 IS_FINISHED = 'is_finished'
+CREATION_DATE = 'creation_date'
+MODIFICATION_DATE = 'modification_date'
 
 # User
 USER = 'user'

--- a/backend/papersfeed/constants.py
+++ b/backend/papersfeed/constants.py
@@ -39,6 +39,7 @@ IS_FOLLOWING = 'is_following'
 IS_FOLLOWED = 'is_followed'
 FOLLOWER = 'follower'
 FOLLOWING = 'following'
+COLLECTION_USER_TYPE = 'collection_user_type'
 
 # Notification
 NOTIFICATION = 'notification'

--- a/backend/papersfeed/tests/tests_collection.py
+++ b/backend/papersfeed/tests/tests_collection.py
@@ -166,7 +166,7 @@ class CollectionTestCase(TestCase):
 
         paper_id = Paper.objects.filter(title='paper1').first().id
 
-        # Add paper to test_collection_1
+        # Add paper to 'SWPP Papers'
         client.put('/api/paper/collection',
                    json.dumps({
                        constants.ID: paper_id,

--- a/backend/papersfeed/tests/tests_collection.py
+++ b/backend/papersfeed/tests/tests_collection.py
@@ -4,6 +4,7 @@ import json
 
 from django.test import TestCase, Client
 from papersfeed import constants
+from papersfeed.models.papers.paper import Paper
 from papersfeed.models.collections.collection import Collection
 from papersfeed.models.users.user import User
 
@@ -136,24 +137,9 @@ class CollectionTestCase(TestCase):
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
         self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
-        collection_id = Collection.objects.filter(title='SWPP Papers').first().id
-        self.assertJSONEqual(response.content, {
-            constants.COLLECTIONS: [{
-                constants.ID: collection_id,
-                constants.TITLE: 'SWPP Papers',
-                constants.TEXT: 'papers for swpp 2019 class',
-                constants.LIKED: False,
-                constants.CONTAINS_PAPER: False,
-                constants.COUNT: {
-                    constants.USERS: 1,
-                    constants.PAPERS: 0,
-                    constants.LIKES: 0,
-                    constants.REPLIES: 0,
-                }
-            }],
-            constants.PAGE_NUMBER: 1,
-            constants.IS_FINISHED: True
-        })
+        collections = json.loads(response.content)[constants.COLLECTIONS]
+        self.assertEqual(len(collections), 1)
+        self.assertEqual(collections[0][constants.TITLE], 'SWPP Papers')
 
     def test_get_collections_of_user_with_paper(self):
         """ GET USER'S COLLECTIONS """
@@ -169,11 +155,30 @@ class CollectionTestCase(TestCase):
 
         user_id = User.objects.filter(email='swpp@snu.ac.kr').first().id
 
+        # Creating papers
+        Paper.objects.create(
+            title="paper1",
+            language="English",
+            abstract="abstract1",
+        )
+
+        collection_id = Collection.objects.filter(title='SWPP Papers').first().id
+
+        paper_id = Paper.objects.filter(title='paper1').first().id
+
+        # Add paper to test_collection_1
+        client.put('/api/paper/collection',
+                   json.dumps({
+                       constants.ID: paper_id,
+                       constants.COLLECTION_IDS: [collection_id]
+                   }),
+                   content_type='application/json')
+
         # Get User's Collections
         response = client.get('/api/collection/user',
                               data={
                                   constants.ID: user_id,
-                                  constants.PAPER: 1,
+                                  constants.PAPER: paper_id,
                               },
                               content_type='application/json')
 
@@ -181,24 +186,10 @@ class CollectionTestCase(TestCase):
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
         self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 
-        collection_id = Collection.objects.filter(title='SWPP Papers').first().id
-        self.assertJSONEqual(response.content, {
-            constants.COLLECTIONS: [{
-                constants.ID: collection_id,
-                constants.TITLE: 'SWPP Papers',
-                constants.TEXT: 'papers for swpp 2019 class',
-                constants.LIKED: False,
-                constants.CONTAINS_PAPER: False,
-                constants.COUNT: {
-                    constants.USERS: 1,
-                    constants.PAPERS: 0,
-                    constants.LIKES: 0,
-                    constants.REPLIES: 0,
-                }
-            }],
-            constants.PAGE_NUMBER: 1,
-            constants.IS_FINISHED: True
-        })
+        collections = json.loads(response.content)[constants.COLLECTIONS]
+        self.assertEqual(len(collections), 1)
+        self.assertEqual(collections[0][constants.TITLE], 'SWPP Papers')
+        self.assertEqual(collections[0][constants.CONTAINS_PAPER], True)
 
     def test_delete_collection(self):
         """ DELETE Collection """

--- a/backend/papersfeed/tests/tests_replies.py
+++ b/backend/papersfeed/tests/tests_replies.py
@@ -4,7 +4,6 @@ import json
 
 from django.test import TestCase, Client
 from papersfeed import constants
-from papersfeed.models.users.user import User
 from papersfeed.models.papers.paper import Paper
 from papersfeed.models.reviews.review import Review
 from papersfeed.models.collections.collection import Collection
@@ -130,10 +129,8 @@ class ReplyTestCase(TestCase):
                    },
                    content_type='application/json')
 
-        user_id = User.objects.filter(email='swpp@snu.ac.kr').first().id
         collection_id = Collection.objects.filter(title='test_collection_1').first().id
         review_id = Review.objects.filter(title="test_review_1").first().id
-        collection_reply_id = ReplyCollection.objects.filter(collection_id=collection_id).first().reply_id
 
         # Get Replies Collection
         response = client.get('/api/reply/collection',
@@ -143,18 +140,11 @@ class ReplyTestCase(TestCase):
                               content_type='application/json')
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            '{"replies": [{"id": ' + str(collection_reply_id)
-            + ', "text": "test_reply_1", "liked": false, "review": {}, "collection": {"id":'
-            + ' ' + str(collection_id)
-            + ', "title": "test_collection_1", "text": "test_collection_1", "liked": false, '
-            + '"contains_paper": false, "count": {"users": 1, "papers": 0, "likes": 0, "replies": 1}},'
-            + ' "user": {"id": ' + str(user_id)
-            + ', "username": "swpp", "email": "swpp@snu.ac.kr", "description": "", '
-            + '"count": {"follower": 0, "following": 0}}, "count": {"likes": 0}}], '
-            + '"page_number": 1, '
-            + '"is_finished": true}',
-            response.content.decode())
+
+        replies = json.loads(response.content)[constants.REPLIES]
+        self.assertEqual(len(replies), 1)
+        self.assertEqual(replies[0][constants.TEXT], "test_reply_1")
+
         self.assertEqual(json.loads(response.content.decode())[constants.IS_FINISHED], True)
         self.assertEqual(int(json.loads(response.content.decode())[constants.PAGE_NUMBER]), 1)
 

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -647,7 +647,7 @@ class UserTestCase(TestCase):
         response = client.delete('/api/user/collection',
                                  json.dumps({
                                      constants.ID: collection_id,
-                                     constants.USER_IDS: user_ids
+                                     constants.USER_IDS: str(user_ids)
                                  }),
                                  content_type='application/json')
 

--- a/backend/papersfeed/tests/tests_user.py
+++ b/backend/papersfeed/tests/tests_user.py
@@ -628,24 +628,26 @@ class UserTestCase(TestCase):
 
         collection_id = Collection.objects.filter(title='SWPP Papers').first().id
 
-        user_id = User.objects.filter(email='swpp2@snu.ac.kr').first().id
+        user_ids = []
+        user_ids.append(User.objects.filter(email='swpp2@snu.ac.kr').first().id)
+        user_ids.append(User.objects.filter(email='swpp3@snu.ac.kr').first().id)
 
         # Add the User to the Collection
         response = client.post('/api/user/collection',
                                json.dumps({
                                    constants.ID: collection_id,
-                                   constants.USER_IDS: [user_id]
+                                   constants.USER_IDS: user_ids
                                }),
                                content_type='application/json')
 
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(json.loads(response.content)['count']['users'], 2)
+        self.assertEqual(json.loads(response.content)['count']['users'], 3)
 
         # Delete the User from the Collection
         response = client.delete('/api/user/collection',
                                  json.dumps({
                                      constants.ID: collection_id,
-                                     constants.USER_IDS: [user_id]
+                                     constants.USER_IDS: user_ids
                                  }),
                                  content_type='application/json')
 

--- a/backend/papersfeed/utils/__init__.py
+++ b/backend/papersfeed/utils/__init__.py
@@ -1,8 +1,0 @@
-"""__init__.py"""
-from papersfeed.utils.users.utils import *
-from papersfeed.utils.papers.utils import *
-from papersfeed.utils.collections.utils import *
-from papersfeed.utils.reviews.utils import *
-from papersfeed.utils.replies.utils import *
-from papersfeed.utils.likes.utils import *
-from papersfeed.utils.notifications.utils import *

--- a/backend/papersfeed/utils/__init__.py
+++ b/backend/papersfeed/utils/__init__.py
@@ -1,0 +1,8 @@
+"""__init__.py"""
+from papersfeed.utils.users.utils import *
+from papersfeed.utils.papers.utils import *
+from papersfeed.utils.collections.utils import *
+from papersfeed.utils.reviews.utils import *
+from papersfeed.utils.replies.utils import *
+from papersfeed.utils.likes.utils import *
+from papersfeed.utils.notifications.utils import *

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -320,12 +320,12 @@ def __get_collections(filter_query, request_user, count, paper_id=None, order_by
 
     is_finished = len(collections) < count if count and pagination_value != 0 else True
 
-    collections = __pack_collections(collections, request_user)
+    collections = __pack_collections(collections, request_user, paper_id=paper_id)
 
     return collections, pagination_value, is_finished
 
 
-def __pack_collections(collections, request_user):  # pylint: disable=unused-argument
+def __pack_collections(collections, request_user, paper_id=None):  # pylint: disable=unused-argument
     """Pack Collections"""
     packed = []
 
@@ -351,14 +351,16 @@ def __pack_collections(collections, request_user):  # pylint: disable=unused-arg
             constants.TITLE: collection.title,
             constants.TEXT: collection.text,
             constants.LIKED: collection.is_liked,
-            constants.CONTAINS_PAPER: collection.contains_paper,
             constants.COUNT: {
                 constants.USERS: user_counts[collection_id] if collection_id in user_counts else 0,
                 constants.PAPERS: paper_counts[collection_id] if collection_id in paper_counts else 0,
                 constants.LIKES: like_counts[collection_id] if collection_id in like_counts else 0,
                 constants.REPLIES: reply_counts[collection_id] if collection_id in reply_counts else 0
-            }
+            },
         }
+
+        if paper_id:
+            packed_collection[constants.CONTAINS_PAPER] = collection.contains_paper,
 
         packed.append(packed_collection)
 

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -3,7 +3,6 @@
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q, Exists, OuterRef, Count, Case, When
-from django.utils import timezone
 
 from papersfeed import constants
 from papersfeed.utils.base_utils import is_parameter_exists, get_results_from_queryset, ApiError
@@ -363,7 +362,7 @@ def __pack_collections(collections, request_user, paper_id=None):  # pylint: dis
         }
 
         if paper_id:
-            packed_collection[constants.CONTAINS_PAPER] = collection.contains_paper,
+            packed_collection[constants.CONTAINS_PAPER] = collection.contains_paper
 
         packed.append(packed_collection)
 

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -3,6 +3,7 @@
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q, Exists, OuterRef, Count, Case, When
+from django.utils import timezone
 
 from papersfeed import constants
 from papersfeed.utils.base_utils import is_parameter_exists, get_results_from_queryset, ApiError
@@ -357,6 +358,8 @@ def __pack_collections(collections, request_user, paper_id=None):  # pylint: dis
                 constants.LIKES: like_counts[collection_id] if collection_id in like_counts else 0,
                 constants.REPLIES: reply_counts[collection_id] if collection_id in reply_counts else 0
             },
+            constants.CREATION_DATE: collection.creation_date,
+            constants.MODIFICATION_DATE: collection.modification_date
         }
 
         if paper_id:

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -11,7 +11,6 @@ from papersfeed.models.collections.collection_like import CollectionLike
 from papersfeed.models.collections.collection_user import CollectionUser, COLLECTION_USER_TYPE
 from papersfeed.models.collections.collection_paper import CollectionPaper
 from papersfeed.models.replies.reply_collection import ReplyCollection
-# from papersfeed.models.users.user import User
 
 
 def insert_collection(args):

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -395,7 +395,7 @@ def select_user_collection(args):
     member_ids = list(set(member_ids))
 
     # Get Members
-    members, _, is_finished = __get_users(Q(id__in=member_ids), request_user, 10)
+    members, _, is_finished = __get_users(Q(id__in=member_ids), request_user, 10, collection_id=collection_id)
 
     return members, page_number, is_finished
 
@@ -505,7 +505,7 @@ def remove_user_collection(args):
     return {constants.USERS: user_counts[collection_id] if collection_id in user_counts else 0}
 
 
-def __get_users(filter_query, request_user, count):
+def __get_users(filter_query, request_user, count, collection_id=None):
     """Get Users By Query"""
     queryset = User.objects.filter(
         filter_query
@@ -520,12 +520,12 @@ def __get_users(filter_query, request_user, count):
 
     is_finished = len(users) < count if count and pagination_value != 0 else True
 
-    users = __pack_users(users, request_user)
+    users = __pack_users(users, request_user, collection_id=collection_id)
 
     return users, pagination_value, is_finished
 
 
-def __pack_users(users, request_user):
+def __pack_users(users, request_user, collection_id=None):
     """Pack User Info"""
     packed = []
 
@@ -555,6 +555,11 @@ def __pack_users(users, request_user):
             # 내 정보가 아니면 follow 관계 여부 추가
             packed_user[constants.IS_FOLLOWED] = user.is_followed
             packed_user[constants.IS_FOLLOWING] = user.is_following
+
+        if collection_id:
+            packed_user[constants.COLLECTION_USER_TYPE] = CollectionUser.objects.get(
+                user_id=user_id, collection_id=collection_id
+            ).type
 
         packed.append(packed_user)
 

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import uuid
 import hashlib
+import json
 
 from django.db import IntegrityError, transaction
 from django.core.exceptions import ObjectDoesNotExist
@@ -472,14 +473,13 @@ def update_user_collection(args):
 
 
 def remove_user_collection(args):
-    """Remove the User(s) from the Collection"""
+    """Remove the Users from the Collection"""
     is_parameter_exists([
         constants.ID, constants.USER_IDS
     ], args)
 
     collection_id = int(args[constants.ID])
-    # user_id = args[constants.USER_ID]
-    user_ids = args[constants.USER_IDS]
+    user_ids = json.loads(args[constants.USER_IDS])
 
     request_user = args[constants.USER]
 
@@ -497,17 +497,8 @@ def remove_user_collection(args):
     # or deleting the collection would be a solution
     if request_user.id in user_ids:
         raise ApiError(constants.UNPROCESSABLE_ENTITY)
-    # original codes
-    # user_counts = __get_collection_user_count([collection_id], 'collection_id')
-    # user_count = user_counts[collection_id] if collection_id in user_counts else 0
 
-    # # if there are more than two members, owner can't just leave
-    # if user_count > 1 and user_id == request_user.id:
-    #     raise ApiError(constants.UNPROCESSABLE_ENTITY)
-
-    # FIXME : there may better way to delete multiple users
-    for user_id in user_ids:
-        CollectionUser.objects.filter(user_id=user_id, collection_id=collection_id).delete()
+    CollectionUser.objects.filter(user_id__in=user_ids, collection_id=collection_id).delete()
 
     # Get the number of Members(including owner) Of Collections
     user_counts = __get_collection_user_count([collection_id], 'collection_id')

--- a/backend/papersfeed/utils/users/utils.py
+++ b/backend/papersfeed/utils/users/utils.py
@@ -415,11 +415,6 @@ def insert_user_collection(args):
     if not Collection.objects.filter(id=collection_id).exists():
         raise ApiError(constants.NOT_EXIST_OBJECT)
 
-    # if request_user is not owner, then raise AUTH_ERROR
-    collection_user = CollectionUser.objects.get(collection_id=collection_id, user_id=request_user.id)
-    if collection_user.type != COLLECTION_USER_TYPE[0]:
-        raise ApiError(constants.AUTH_ERROR)
-
     # Self Add
     if request_user.id in user_ids:
         raise ApiError(constants.UNPROCESSABLE_ENTITY)

--- a/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.js
+++ b/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.js
@@ -23,16 +23,21 @@ class CreateNewCollectionModal extends Component {
     }
 
     clickCreateHandler = () => {
+        const newCollectionDesc = this.state.newCollectionDesc.length > 0
+            ? this.state.newCollectionDesc : `This is ${this.state.newCollectionName} collection.`;
+
         this.props.onCreateNewCollection({
             title: this.state.newCollectionName,
-            text: this.state.newCollectionDesc,
-        });
-        this.props.onUpdateCollection({ id: this.props.me.id });
-        this.setState({
-            isModalOpen: false,
-            newCollectionName: "",
-            newCollectionDesc: "",
-        });
+            text: newCollectionDesc,
+        })
+            .then(() => {
+                this.props.onUpdateCollection({ id: this.props.me.id });
+                this.setState({
+                    isModalOpen: false,
+                    newCollectionName: "",
+                    newCollectionDesc: "",
+                });
+            });
     }
 
     clickCancelHandler = () => {
@@ -48,7 +53,7 @@ class CreateNewCollectionModal extends Component {
             <div className="CreateNewCollectionModal">
                 <div id="openButtonDiv">
                     <Button id="modalOpenButton" onClick={this.clickOpenHandler}>
-                        Create New ...
+                        Create New...
                     </Button>
                 </div>
                 <Modal id="createModal" show={this.state.isModalOpen} onHide={this.clickCancelHandler} centered>

--- a/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
+++ b/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
@@ -2,52 +2,11 @@ import React from "react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 
-import { getMockStore } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import { collectionActions } from "../../../store/actions";
 import CreateNewCollectionModal from "./CreateNewCollectionModal";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
 
-const stubInitialState = {
-    paper: {
-    },
-    auth: {
-        signinStatus: signinStatus.SUCCESS,
-        me: { id: 1 },
-    },
-    collection: {
-        make: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        list: {
-            status: collectionStatus.NONE,
-            list: [],
-            error: null,
-        },
-        edit: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        delete: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        selected: {
-            status: collectionStatus.NONE,
-            error: null,
-            collection: {},
-            papers: [],
-            members: [],
-            replies: [],
-        },
-    },
-    user: {},
-    review: {},
-    reply: {},
-};
 
 const makeCreateNewCollectionModal = (initialState) => (
     <Provider store={getMockStore(initialState)}>
@@ -55,14 +14,52 @@ const makeCreateNewCollectionModal = (initialState) => (
     </Provider>
 );
 
-/* eslint-disable no-unused-vars */
-const mockPromise = new Promise((resolve, reject) => { resolve(); });
-/* eslint-enable no-unused-vars */
-
 describe("CreateNewCollection test", () => {
+    let stubInitialState;
     let createNewCollection;
 
     beforeEach(() => {
+        stubInitialState = {
+            paper: {
+            },
+            auth: {
+                signinStatus: signinStatus.SUCCESS,
+                me: { id: 1 },
+            },
+            collection: {
+                make: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                list: {
+                    status: collectionStatus.NONE,
+                    list: [],
+                    error: null,
+                },
+                edit: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                delete: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                selected: {
+                    status: collectionStatus.NONE,
+                    error: null,
+                    collection: {},
+                    papers: [],
+                    members: [],
+                    replies: [],
+                },
+            },
+            user: {},
+            review: {},
+            reply: {},
+        };
         createNewCollection = makeCreateNewCollectionModal(stubInitialState);
     });
 
@@ -100,7 +97,7 @@ describe("CreateNewCollection test", () => {
         expect(instance.state.newCollectionDesc).toBe("qwer");
     });
 
-    it("should handle making new collection", () => {
+    it("should handle making new collection", async () => {
         // mocking actions
         /* eslint-disable no-unused-vars */
         const spyMakeNewCollection = jest.spyOn(collectionActions, "makeNewCollection")
@@ -123,8 +120,12 @@ describe("CreateNewCollection test", () => {
 
         // expect actions to be called
         expect(spyMakeNewCollection).toHaveBeenCalledTimes(1);
-        expect(spyGetCollectionsByUserId).toHaveBeenCalledTimes(0); // FIXME: async problems
+
+        await flushPromises();
+        component.update();
+
+        expect(spyGetCollectionsByUserId).toHaveBeenCalledTimes(1);
         const instance = component.find("CreateNewCollectionModal").instance();
-        expect(instance.state.isModalOpen).toBe(true); // FIXME: async problems
+        expect(instance.state.isModalOpen).toBe(false);
     });
 });

--- a/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
+++ b/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
@@ -123,8 +123,8 @@ describe("CreateNewCollection test", () => {
 
         // expect actions to be called
         expect(spyMakeNewCollection).toHaveBeenCalledTimes(1);
-        expect(spyGetCollectionsByUserId).toHaveBeenCalledTimes(1);
+        expect(spyGetCollectionsByUserId).toHaveBeenCalledTimes(0); // FIXME: async problems
         const instance = component.find("CreateNewCollectionModal").instance();
-        expect(instance.state.isModalOpen).toBe(false);
+        expect(instance.state.isModalOpen).toBe(true); // FIXME: async problems
     });
 });

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
@@ -161,7 +161,6 @@ const mapDispatchToProps = (dispatch) => ({
     onInviteUsers: (collectionId, userIdList) => dispatch(
         collectionActions.addNewMembers(collectionId, userIdList),
     ),
-    onGetCollection: (collectionId) => dispatch(collectionActions.getCollection(collectionId)),
     onGetMembers: (collectionId) => dispatch(
         collectionActions.getCollectionMembers(collectionId),
     ),

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
@@ -67,7 +67,7 @@ class InviteToCollectionModal extends Component {
                     isModalOpen: false,
                     checkedUserIdList: [],
                 });
-                this.props.onGetCollection({ id: this.props.thisCollection.id });
+                this.props.onGetMembers(this.props.thisCollection.id);
             });
     }
 
@@ -162,6 +162,9 @@ const mapDispatchToProps = (dispatch) => ({
         collectionActions.addNewMembers(collectionId, userIdList),
     ),
     onGetCollection: (collectionId) => dispatch(collectionActions.getCollection(collectionId)),
+    onGetMembers: (collectionId) => dispatch(
+        collectionActions.getCollectionMembers(collectionId),
+    ),
 });
 
 
@@ -179,7 +182,7 @@ InviteToCollectionModal.propTypes = {
     onGetFollowings: PropTypes.func,
     onSearchUsers: PropTypes.func,
     onInviteUsers: PropTypes.func,
-    onGetCollection: PropTypes.func,
+    onGetMembers: PropTypes.func,
 };
 
 InviteToCollectionModal.defaultProps = {
@@ -194,5 +197,5 @@ InviteToCollectionModal.defaultProps = {
     onGetFollowings: () => {},
     onSearchUsers: () => {},
     onInviteUsers: () => {},
-    onGetCollection: () => {},
+    onGetMembers: () => {},
 };

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
@@ -15,6 +15,13 @@ class InviteToCollectionModal extends Component {
             isSearchResult: false,
             checkedUserIdList: [],
         };
+
+        this.clickOpenHandler = this.clickOpenHandler.bind(this);
+        this.clickCancelHandler = this.clickCancelHandler.bind(this);
+        this.clickSearchHandler = this.clickSearchHandler.bind(this);
+        this.clickInviteUsersHandler = this.clickInviteUsersHandler.bind(this);
+        this.checkHandler = this.checkHandler.bind(this);
+        this.userEntryMapper = this.userEntryMapper.bind(this);
     }
 
     // handler functions for buttons

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
@@ -46,13 +46,16 @@ class InviteToCollectionModal extends Component {
 
     clickInviteUsersHandler = () => {
         // console.log(this.state.checkedUserIdList);
-        this.props.onInviteUsers(this.props.thisCollection.id, this.state.checkedUserIdList);
-        this.setState({
-            searchKeyWord: "",
-            isModalOpen: false,
-            isSearchResult: false,
-            checkedUserIdList: [],
-        });
+        this.props.onInviteUsers(this.props.thisCollection.id, this.state.checkedUserIdList)
+            .then(() => {
+                this.setState({
+                    searchKeyWord: "",
+                    isModalOpen: false,
+                    isSearchResult: false,
+                    checkedUserIdList: [],
+                });
+                this.props.onGetCollection({ id: this.props.thisCollection.id });
+            });
     }
 
     // handler function for user entry
@@ -147,6 +150,7 @@ const mapDispatchToProps = (dispatch) => ({
     onInviteUsers: (collectionId, userIdList) => dispatch(
         collectionActions.addNewMembers(collectionId, userIdList),
     ),
+    onGetCollection: (collectionId) => dispatch(collectionActions.getCollection(collectionId)),
 });
 
 
@@ -163,6 +167,7 @@ InviteToCollectionModal.propTypes = {
     onGetFollowings: PropTypes.func,
     onSearchUsers: PropTypes.func,
     onInviteUsers: PropTypes.func,
+    onGetCollection: PropTypes.func,
 };
 
 InviteToCollectionModal.defaultProps = {
@@ -176,4 +181,5 @@ InviteToCollectionModal.defaultProps = {
     onGetFollowings: () => {},
     onSearchUsers: () => {},
     onInviteUsers: () => {},
+    onGetCollection: () => {},
 };

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.js
@@ -12,7 +12,8 @@ class InviteToCollectionModal extends Component {
         this.state = {
             searchKeyWord: "",
             isModalOpen: false,
-            isSearchResult: false,
+            memberIds: [],
+            users: [],
             checkedUserIdList: [],
         };
 
@@ -26,32 +27,44 @@ class InviteToCollectionModal extends Component {
 
     // handler functions for buttons
     clickOpenHandler = () => {
-        this.setState({ isModalOpen: true });
-        this.props.onGetFollowings({ id: this.props.me.id });
+        this.setState({ memberIds: this.props.members.map((x) => x.id) });
+        this.props.onGetFollowings({ id: this.props.me.id })
+            .then(() => {
+                const { memberIds } = this.state;
+                this.setState({
+                    isModalOpen: true,
+                    users: this.props.myFollowings
+                        .filter((x) => !memberIds.includes(x.id)),
+                });
+            });
     }
 
     clickCancelHandler = () => {
         this.setState({
             searchKeyWord: "",
             isModalOpen: false,
-            isSearchResult: false,
             checkedUserIdList: [],
         });
     }
 
     clickSearchHandler = () => {
-        this.setState({ isSearchResult: true, checkedUserIdList: [] });
-        this.props.onSearchUsers({ text: this.state.searchKeyWord });
+        this.setState({ checkedUserIdList: [] });
+        this.props.onSearchUsers({ text: this.state.searchKeyWord })
+            .then(() => {
+                const { memberIds } = this.state;
+                this.setState({
+                    users: this.props.searchedUsers
+                        .filter((x) => !memberIds.includes(x.id)),
+                });
+            });
     }
 
     clickInviteUsersHandler = () => {
-        // console.log(this.state.checkedUserIdList);
         this.props.onInviteUsers(this.props.thisCollection.id, this.state.checkedUserIdList)
             .then(() => {
                 this.setState({
                     searchKeyWord: "",
                     isModalOpen: false,
-                    isSearchResult: false,
                     checkedUserIdList: [],
                 });
                 this.props.onGetCollection({ id: this.props.thisCollection.id });
@@ -85,9 +98,7 @@ class InviteToCollectionModal extends Component {
     ))
 
     render() {
-        const userEntries = this.state.isSearchResult
-            ? this.userEntryMapper(this.props.searchedUsers)
-            : this.userEntryMapper(this.props.myFollowings);
+        const userEntries = this.userEntryMapper(this.state.users);
 
         return (
             <div className="InviteToCollectionModal">
@@ -160,6 +171,7 @@ InviteToCollectionModal.propTypes = {
     openButtonName: PropTypes.string,
 
     thisCollection: PropTypes.objectOf(PropTypes.any),
+    members: PropTypes.arrayOf(PropTypes.any),
     myFollowings: PropTypes.arrayOf(PropTypes.any),
     searchedUsers: PropTypes.arrayOf(PropTypes.any),
     me: PropTypes.objectOf(PropTypes.any),
@@ -174,6 +186,7 @@ InviteToCollectionModal.defaultProps = {
     openButtonName: "",
 
     thisCollection: {},
+    members: [],
     myFollowings: [],
     searchedUsers: [],
     me: null,

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
@@ -7,49 +7,6 @@ import { collectionActions, userActions } from "../../../store/actions";
 import InviteToCollectionModal from "./InviteToCollectionModal";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
 
-const stubInitialState = {
-    paper: {
-    },
-    auth: {
-        signinStatus: signinStatus.SUCCESS,
-        me: { id: 4 },
-    },
-    collection: {
-        make: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        list: {
-            status: collectionStatus.NONE,
-            list: [],
-            error: null,
-        },
-        edit: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        delete: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        selected: {
-            status: collectionStatus.NONE,
-            error: null,
-            collection: {},
-            papers: [],
-            members: [],
-            memberCount: 0,
-            replies: [],
-        },
-    },
-    user: {},
-    review: {},
-    reply: {},
-};
-
 const makeInviteToCollectionModal = (initialState) => (
     <Provider store={getMockStore(initialState)}>
         <InviteToCollectionModal />
@@ -59,12 +16,84 @@ const makeInviteToCollectionModal = (initialState) => (
 /* eslint-disable no-unused-vars */
 const mockPromise = new Promise((resolve, reject) => { resolve(); });
 /* eslint-enable no-unused-vars */
+const flushPromises = () => new Promise(setImmediate);
 
 describe("InviteToCollectionModal test", () => {
+    let stubInitialState;
     let inviteToCollectionModal;
+    let spyGetFollowings;
+    let spyAddNewMemers;
+    let spySearch;
 
     beforeEach(() => {
+        stubInitialState = {
+            paper: {
+            },
+            auth: {
+                signinStatus: signinStatus.SUCCESS,
+                me: { id: 4 },
+            },
+            collection: {
+                make: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                list: {
+                    status: collectionStatus.NONE,
+                    list: [],
+                    error: null,
+                },
+                edit: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                delete: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                selected: {
+                    status: collectionStatus.NONE,
+                    error: null,
+                    collection: {},
+                    papers: [],
+                    members: [],
+                    memberCount: 0,
+                    replies: [],
+                },
+            },
+            user: {
+                selectedFollowing: [
+                    {
+                        id: 1,
+                        username: "test1",
+                        description: "asdf",
+                    },
+                    {
+                        id: 2,
+                        username: "test2",
+                        description: "qwer",
+                    },
+                    {
+                        id: 3,
+                        username: "test3",
+                        description: "zxcv",
+                    },
+                ],
+            },
+            review: {},
+            reply: {},
+        };
+
         inviteToCollectionModal = makeInviteToCollectionModal(stubInitialState);
+        spyGetFollowings = jest.spyOn(userActions, "getFollowingsByUserId")
+            .mockImplementation(() => () => mockPromise);
+        spyAddNewMemers = jest.spyOn(collectionActions, "addNewMembers")
+            .mockImplementation(() => () => mockPromise);
+        spySearch = jest.spyOn(userActions, "searchUser")
+            .mockImplementation(() => () => mockPromise);
     });
 
     afterEach(() => {
@@ -77,21 +106,19 @@ describe("InviteToCollectionModal test", () => {
         expect(wrapper.length).toBe(1);
     });
 
-    it("should set state to open/close modal", () => {
-        const spyGetFollowings = jest.spyOn(userActions, "getFollowingsByUserId")
-            .mockImplementation(() => () => mockPromise);
-
+    it("should set state to open/close modal", async () => {
         const component = mount(inviteToCollectionModal);
 
         // open and call getFollowingsByUserId by pressing open button
         let wrapper = component.find("#modalOpenButton").hostNodes();
         expect(wrapper.length).toBe(1);
         wrapper.simulate("click");
-        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
         expect(spyGetFollowings).toHaveBeenCalledTimes(1);
-        expect(instance.state.isModalOpen).toBe(false); // FIXME: async problems
 
-        instance.setState({ isModalOpen: true });
+        await flushPromises();
+
+        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+        expect(instance.state.isModalOpen).toBe(true);
         component.update();
 
         // close by pressing cancel button
@@ -131,9 +158,6 @@ describe("InviteToCollectionModal test", () => {
     });
 
     it("should call addNewMembers when inviting", () => {
-        const spyAddNewMemers = jest.spyOn(collectionActions, "addNewMembers")
-            .mockImplementation(() => () => mockPromise);
-
         const component = mount(inviteToCollectionModal);
         const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
         instance.setState({
@@ -165,9 +189,6 @@ describe("InviteToCollectionModal test", () => {
     });
 
     it("should handle search", () => {
-        const spySearch = jest.spyOn(userActions, "searchUser")
-            .mockImplementation(() => () => mockPromise);
-
         const component = mount(inviteToCollectionModal);
 
         const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 
-import { getMockStore } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import { collectionActions, userActions } from "../../../store/actions";
 import InviteToCollectionModal from "./InviteToCollectionModal";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
@@ -12,11 +12,6 @@ const makeInviteToCollectionModal = (initialState) => (
         <InviteToCollectionModal />
     </Provider>
 );
-
-/* eslint-disable no-unused-vars */
-const mockPromise = new Promise((resolve, reject) => { resolve(); });
-/* eslint-enable no-unused-vars */
-const flushPromises = () => new Promise(setImmediate);
 
 jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
     <input

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
@@ -18,6 +18,16 @@ const mockPromise = new Promise((resolve, reject) => { resolve(); });
 /* eslint-enable no-unused-vars */
 const flushPromises = () => new Promise(setImmediate);
 
+jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
+    <input
+      className="entryItem"
+      id="check"
+      type="checkbox"
+      checked={props.isChecked}
+      onChange={props.checkhandler}
+    />
+)));
+
 describe("InviteToCollectionModal test", () => {
     let stubInitialState;
     let inviteToCollectionModal;
@@ -153,7 +163,7 @@ describe("InviteToCollectionModal test", () => {
         });
         component.update();
 
-        const wrapper = component.find(".UserEntry").hostNodes();
+        const wrapper = component.find(".entryItem");
         expect(wrapper.length).toBe(3);
     });
 
@@ -179,11 +189,15 @@ describe("InviteToCollectionModal test", () => {
                     description: "zxcv",
                 },
             ],
-            checkedUserIdList: [1],
         });
         component.update();
 
-        const wrapper = component.find("#inviteButton").hostNodes();
+        let wrapper = component.find("#check").at(0); // test1
+        expect(wrapper.length).toBe(1);
+        wrapper.simulate("change", { target: { checked: true } });
+        expect(instance.state.checkedUserIdList).toEqual([1]);
+
+        wrapper = component.find("#inviteButton").hostNodes();
         wrapper.simulate("click");
         expect(spyAddNewMemers).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
+++ b/frontend/src/components/Modal/InviteToCollectionModal/InviteToCollectionModal.test.js
@@ -3,7 +3,7 @@ import { mount } from "enzyme";
 import { Provider } from "react-redux";
 
 import { getMockStore } from "../../../test-utils/mocks";
-import { userActions } from "../../../store/actions";
+import { collectionActions, userActions } from "../../../store/actions";
 import InviteToCollectionModal from "./InviteToCollectionModal";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
 
@@ -12,7 +12,7 @@ const stubInitialState = {
     },
     auth: {
         signinStatus: signinStatus.SUCCESS,
-        me: { id: 1 },
+        me: { id: 4 },
     },
     collection: {
         make: {
@@ -41,6 +41,7 @@ const stubInitialState = {
             collection: {},
             papers: [],
             members: [],
+            memberCount: 0,
             replies: [],
         },
     },
@@ -71,26 +72,27 @@ describe("InviteToCollectionModal test", () => {
     });
 
     it("should render without errors", () => {
+        const component = mount(inviteToCollectionModal);
+        const wrapper = component.find(".InviteToCollectionModal");
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("should set state to open/close modal", () => {
         const spyGetFollowings = jest.spyOn(userActions, "getFollowingsByUserId")
             .mockImplementation(() => () => mockPromise);
 
         const component = mount(inviteToCollectionModal);
-        const wrapper = component.find(".InviteToCollectionModal");
-        expect(wrapper.length).toBe(1);
 
-        // FIXME : it should be '1'
-        expect(spyGetFollowings).toHaveBeenCalledTimes(0);
-    });
-
-    it("should set state to open/close modal", () => {
-        const component = mount(inviteToCollectionModal);
-
-        // open by pressing open button
+        // open and call getFollowingsByUserId by pressing open button
         let wrapper = component.find("#modalOpenButton").hostNodes();
         expect(wrapper.length).toBe(1);
         wrapper.simulate("click");
-        const instance = component.find("InviteToCollectionModal").instance();
-        expect(instance.state.isModalOpen).toBe(true);
+        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+        expect(spyGetFollowings).toHaveBeenCalledTimes(1);
+        expect(instance.state.isModalOpen).toBe(false); // FIXME: async problems
+
+        instance.setState({ isModalOpen: true });
+        component.update();
 
         // close by pressing cancel button
         wrapper = component.find("#cancelButton").hostNodes();
@@ -99,21 +101,83 @@ describe("InviteToCollectionModal test", () => {
         expect(instance.state.isModalOpen).toBe(false);
     });
 
-    // it("should show a list of members", () => {
+    it("should show a list of members", () => {
+        const component = mount(inviteToCollectionModal);
+        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+        instance.setState({
+            isModalOpen: true,
+            users: [
+                {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                },
+                {
+                    id: 2,
+                    username: "test2",
+                    description: "qwer",
+                },
+                {
+                    id: 3,
+                    username: "test3",
+                    description: "zxcv",
+                },
+            ],
+        });
+        component.update();
 
-    // })
+        const wrapper = component.find(".UserEntry").hostNodes();
+        expect(wrapper.length).toBe(3);
+    });
+
+    it("should call addNewMembers when inviting", () => {
+        const spyAddNewMemers = jest.spyOn(collectionActions, "addNewMembers")
+            .mockImplementation(() => () => mockPromise);
+
+        const component = mount(inviteToCollectionModal);
+        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+        instance.setState({
+            isModalOpen: true,
+            users: [
+                {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                },
+                {
+                    id: 2,
+                    username: "test2",
+                    description: "qwer",
+                },
+                {
+                    id: 3,
+                    username: "test3",
+                    description: "zxcv",
+                },
+            ],
+            checkedUserIdList: [1],
+        });
+        component.update();
+
+        const wrapper = component.find("#inviteButton").hostNodes();
+        wrapper.simulate("click");
+        expect(spyAddNewMemers).toHaveBeenCalledTimes(1);
+    });
 
     it("should handle search", () => {
         const spySearch = jest.spyOn(userActions, "searchUser")
             .mockImplementation(() => () => mockPromise);
 
         const component = mount(inviteToCollectionModal);
-        let wrapper = component.find("#modalOpenButton").hostNodes();
-        wrapper.simulate("click");
-        wrapper = component.find("#userSearchBar").hostNodes();
+
+        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+        instance.setState({ isModalOpen: true });
+        component.update();
+
+        let wrapper = component.find("#userSearchBar").hostNodes();
         expect(wrapper.length).toBe(1);
         wrapper.simulate("change", { target: { value: "qwer" } });
-        const instance = component.find(InviteToCollectionModal.WrappedComponent).instance();
+
         expect(instance.state.searchKeyWord).toBe("qwer");
         wrapper = component.find("#searchButton").hostNodes();
         wrapper.simulate("click");

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
@@ -17,6 +17,13 @@ class ManageCollectionMemberModal extends Component {
             removeMode: false,
             checkedUserIdList: [],
         };
+
+        this.clickOpenHandler = this.clickOpenHandler.bind(this);
+        this.clickCloseHandler = this.clickCloseHandler.bind(this);
+        this.clickKickOffCancelHandler = this.clickKickOffCancelHandler.bind(this);
+        this.clickKickOffEnableHandler = this.clickKickOffEnableHandler.bind(this);
+        this.checkHandler = this.checkHandler.bind(this);
+        this.confirmDisableCond = this.confirmDisableCond.bind(this);
     }
 
     // opening and closing modal
@@ -39,11 +46,6 @@ class ManageCollectionMemberModal extends Component {
         this.setState({
             removeMode: true,
         });
-    }
-
-    clickKickOffConfirmHandler = () => {
-        // FIXME : 400 bad request
-        // this.props.onDeleteMembers(this.props.thisCollection.id, this.state.checkedUserIdList);
     }
 
     clickKickOffCancelHandler = () => {
@@ -98,7 +100,10 @@ class ManageCollectionMemberModal extends Component {
                       history={this.props.history}
                       openButtonText="Confirm"
                       whatToWarnText={`Kick off following users from "${this.props.thisCollection.title}" \n asdf`}
-                      whatActionWillBeDone={this.clickKickOffConfirmHandler}
+                      whatActionWillBeDone={() => this.props.onDeleteMembers(
+                          this.props.thisCollection.id,
+                          this.state.checkedUserIdList,
+                      )}
                       whereToGoAfterConfirm={`/collection_id=${this.props.thisCollection.id}`}
                       moveAfterDone={false}
                       disableCondition={this.confirmDisableCond()}
@@ -113,11 +118,8 @@ class ManageCollectionMemberModal extends Component {
                 <Button
                   id="kickOffEnableButton"
                   onClick={this.clickKickOffEnableHandler}
-                  disabled
-                  // FIXME : delete these comments and above 'disabled'
-                  // after 'bad request issue' for 'deleteMembers' action function is solved
                 >
-                    Kick Off ...
+                    Kick Off...
                 </Button>
             );
 
@@ -169,7 +171,6 @@ ManageCollectionMemberModal.propTypes = {
     me: PropTypes.objectOf(PropTypes.any),
     thisCollection: PropTypes.objectOf(PropTypes.any),
     members: PropTypes.arrayOf(PropTypes.any),
-    // eslint-disable-next-line react/no-unused-prop-types
     onDeleteMembers: PropTypes.func,
 };
 

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
@@ -135,7 +135,10 @@ class ManageCollectionMemberModal extends Component {
                         <h5 id="createHeaderText">Manage members of {this.props.thisCollection.title}</h5>
                     </Modal.Header>
                     <Modal.Body>
-                        <InviteToCollectionModal openButtonName="Invite New Users" />
+                        <InviteToCollectionModal
+                          openButtonName="Invite New Users"
+                          members={this.props.members}
+                        />
                         <div id="membersListDiv">
                             {memberList}
                         </div>

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
@@ -79,18 +79,20 @@ class ManageCollectionMemberModal extends Component {
 
     render() {
         let memberList = (<div />);
-        if (this.props.members.length > 0) {
-            memberList = this.props.members.map((user) => (
-                <UserEntry
-                  key={user.id}
-                  id={user.id}
-                  userName={user.username}
-                  userDesc={user.descrpition}
-                  isChecked={this.state.checkedUserIdList.includes(user.id)}
-                  checkhandler={() => this.checkHandler(user)}
-                  showCheck={this.state.removeMode}
-                />
-            ));
+        if (this.props.me && this.props.members.length > 0) {
+            memberList = this.props.members
+                .filter((user) => (!this.state.removeMode || user.id !== this.props.me.id))
+                .map((user) => (
+                    <UserEntry
+                      key={user.id}
+                      id={user.id}
+                      userName={user.username}
+                      userDesc={user.descrpition}
+                      isChecked={this.state.checkedUserIdList.includes(user.id)}
+                      checkhandler={() => this.checkHandler(user)}
+                      showCheck={this.state.removeMode}
+                    />
+                ));
         }
 
         const kickOffSupporter = this.state.removeMode

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
@@ -180,7 +180,6 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(mapStateToProps, mapDispatchToProps)(ManageCollectionMemberModal);
 
 ManageCollectionMemberModal.propTypes = {
-    history: PropTypes.objectOf(PropTypes.any),
     me: PropTypes.objectOf(PropTypes.any),
     thisCollection: PropTypes.objectOf(PropTypes.any),
     members: PropTypes.arrayOf(PropTypes.any),
@@ -189,7 +188,6 @@ ManageCollectionMemberModal.propTypes = {
 };
 
 ManageCollectionMemberModal.defaultProps = {
-    history: {},
     me: {},
     thisCollection: {},
     members: [],

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
@@ -4,7 +4,7 @@ import React from "react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 
-import { getMockStore } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import ManageCollectionMemberModal from "./ManageCollectionMemberModal";
 import { collectionActions } from "../../../store/actions";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
@@ -15,11 +15,6 @@ const makeManageCollectionMemberModal = (initialState) => (
         <ManageCollectionMemberModal />
     </Provider>
 );
-
-/* eslint-disable no-unused-vars */
-const mockPromise = new Promise((resolve, reject) => { resolve(); });
-/* eslint-enable no-unused-vars */
-const flushPromises = () => new Promise(setImmediate);
 
 jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
     <input

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
@@ -6,70 +6,9 @@ import { Provider } from "react-redux";
 
 import { getMockStore } from "../../../test-utils/mocks";
 import ManageCollectionMemberModal from "./ManageCollectionMemberModal";
+import { collectionActions } from "../../../store/actions";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
 
-const stubInitialState = {
-    paper: {
-    },
-    auth: {
-        signinStatus: signinStatus.SUCCESS,
-        me: {
-            id: 1,
-            username: "test1",
-            description: "asdf",
-        },
-    },
-    collection: {
-        make: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        list: {
-            status: collectionStatus.NONE,
-            list: [],
-            error: null,
-        },
-        edit: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        delete: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        selected: {
-            collection: {},
-            status: collectionStatus.NONE,
-            error: null,
-            papers: [],
-            members: [
-                {
-                    id: 1,
-                    username: "test1",
-                    description: "asdf",
-                },
-                {
-                    id: 2,
-                    username: "test2",
-                    description: "qwer",
-                },
-                {
-                    id: 3,
-                    username: "test3",
-                    description: "zxcv",
-                },
-            ],
-            memberCount: 3,
-            replies: [],
-        },
-    },
-    user: {},
-    review: {},
-    reply: {},
-};
 
 const makeManageCollectionMemberModal = (initialState) => (
     <Provider store={getMockStore(initialState)}>
@@ -77,12 +16,11 @@ const makeManageCollectionMemberModal = (initialState) => (
     </Provider>
 );
 
-jest.mock("../WarningModal/WarningModal", () => jest.fn((props) => (
-    <button
-      id="mockWarningButton"
-      onClick={props.clickFn}
-    />
-)));
+/* eslint-disable no-unused-vars */
+const mockPromise = new Promise((resolve, reject) => { resolve(); });
+/* eslint-enable no-unused-vars */
+const flushPromises = () => new Promise(setImmediate);
+
 jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
     <input
       className="entryItem"
@@ -94,10 +32,81 @@ jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
 )));
 
 describe("ManageCollectionMemberModal test", () => {
+    let stubInitialState;
     let manageCollectionMemberModal;
+    let spyDeleteMembers;
 
     beforeEach(() => {
+        stubInitialState = {
+            paper: {
+            },
+            auth: {
+                signinStatus: signinStatus.SUCCESS,
+                me: {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                },
+            },
+            collection: {
+                make: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                list: {
+                    status: collectionStatus.NONE,
+                    list: [],
+                    error: null,
+                },
+                edit: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                delete: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                selected: {
+                    collection: {
+                        id: 1,
+                    },
+                    status: collectionStatus.SUCCESS,
+                    error: null,
+                    papers: [],
+                    members: [
+                        {
+                            id: 1,
+                            username: "test1",
+                            description: "asdf",
+                            collection_member_type: "owner",
+                        },
+                        {
+                            id: 2,
+                            username: "test2",
+                            description: "qwer",
+                            collection_member_type: "member",
+                        },
+                        {
+                            id: 3,
+                            username: "test3",
+                            description: "zxcv",
+                            collection_member_type: "member",
+                        },
+                    ],
+                    memberCount: 3,
+                    replies: [],
+                },
+            },
+            user: {},
+            review: {},
+            reply: {},
+        };
         manageCollectionMemberModal = makeManageCollectionMemberModal(stubInitialState);
+        spyDeleteMembers = jest.spyOn(collectionActions, "deleteMembers")
+            .mockImplementation(() => () => mockPromise);
     });
 
     afterEach(() => {
@@ -127,7 +136,7 @@ describe("ManageCollectionMemberModal test", () => {
         expect(instance.state.isModalOpen).toBe(false);
     });
 
-    it("user entries test: should be rendered and handles checking", () => {
+    it("user entries test: should be rendered", () => {
         const component = mount(manageCollectionMemberModal);
         const instance = component.find("ManageCollectionMemberModal").instance();
 
@@ -137,16 +146,19 @@ describe("ManageCollectionMemberModal test", () => {
                     id: 1,
                     username: "test1",
                     description: "asdf",
+                    collection_member_type: "owner",
                 },
                 {
                     id: 2,
                     username: "test2",
                     description: "qwer",
+                    collection_member_type: "member",
                 },
                 {
                     id: 3,
                     username: "test3",
                     description: "zxcv",
+                    collection_member_type: "member",
                 },
             ],
         });
@@ -157,11 +169,57 @@ describe("ManageCollectionMemberModal test", () => {
         wrapper.simulate("click");
         wrapper = component.find(".entryItem");
         expect(wrapper.length).toBe(3);
+    });
 
-        // should handle checking
-        wrapper = component.find("#check").at(0);
+    // more tests should be implemented
+    it("should call deleteCollection when deleting", async () => {
+        const component = mount(manageCollectionMemberModal);
+        const instance = component.find(ManageCollectionMemberModal.WrappedComponent).instance();
+        instance.setState({
+            isModalOpen: true,
+            members: [
+                {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                    collection_member_type: "owner",
+                },
+                {
+                    id: 2,
+                    username: "test2",
+                    description: "qwer",
+                    collection_member_type: "member",
+                },
+                {
+                    id: 3,
+                    username: "test3",
+                    description: "zxcv",
+                    collection_member_type: "member",
+                },
+            ],
+        });
+        component.update();
+
+        let wrapper = component.find("#kickOffEnableButton").hostNodes();
+        expect(wrapper.length).toBe(1);
+        wrapper.simulate("click");
+        component.update();
+
+        wrapper = component.find("#check").at(0); // test2 (excluding 'me')
+        expect(wrapper.length).toBe(1);
         wrapper.simulate("change", { target: { checked: true } });
+        expect(instance.state.checkedUserIdList).toEqual([2]);
 
-        expect(instance.state.checkedUserIdList).toEqual([1]);
+        wrapper = component.find(".WarningModal #modalOpenButton").hostNodes();
+        expect(wrapper.length).toBe(1);
+        wrapper.simulate("click");
+
+        wrapper = component.find(".WarningModal #confirmButton").hostNodes();
+        expect(wrapper.length).toBe(1);
+        wrapper.simulate("click");
+
+        await flushPromises();
+
+        expect(spyDeleteMembers).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
@@ -13,7 +13,11 @@ const stubInitialState = {
     },
     auth: {
         signinStatus: signinStatus.SUCCESS,
-        me: { id: 1 },
+        me: {
+            id: 1,
+            username: "test1",
+            description: "asdf",
+        },
     },
     collection: {
         make: {
@@ -37,27 +41,28 @@ const stubInitialState = {
             error: null,
         },
         selected: {
+            collection: {},
             status: collectionStatus.NONE,
             error: null,
-            collection: {},
             papers: [],
             members: [
                 {
                     id: 1,
                     username: "test1",
-                    userDesc: "asdf",
+                    description: "asdf",
                 },
                 {
                     id: 2,
                     username: "test2",
-                    userDesc: "qwer",
+                    description: "qwer",
                 },
                 {
                     id: 3,
                     username: "test3",
-                    userDesc: "zxcv",
+                    description: "zxcv",
                 },
             ],
+            memberCount: 3,
             replies: [],
         },
     },
@@ -88,7 +93,7 @@ jest.mock("../../User/UserEntry/UserEntry", () => jest.fn((props) => (
     />
 )));
 
-describe("InviteToCollectionModal test", () => {
+describe("ManageCollectionMemberModal test", () => {
     let manageCollectionMemberModal;
 
     beforeEach(() => {
@@ -124,6 +129,28 @@ describe("InviteToCollectionModal test", () => {
 
     it("user entries test: should be rendered and handles checking", () => {
         const component = mount(manageCollectionMemberModal);
+        const instance = component.find("ManageCollectionMemberModal").instance();
+
+        instance.setState({
+            members: [
+                {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                },
+                {
+                    id: 2,
+                    username: "test2",
+                    description: "qwer",
+                },
+                {
+                    id: 3,
+                    username: "test3",
+                    description: "zxcv",
+                },
+            ],
+        });
+        component.update();
 
         // should be rendered
         let wrapper = component.find("#modalOpenButton").hostNodes();
@@ -134,13 +161,7 @@ describe("InviteToCollectionModal test", () => {
         // should handle checking
         wrapper = component.find("#check").at(0);
         wrapper.simulate("change", { target: { checked: true } });
-        const instance = component.find("ManageCollectionMemberModal").instance();
+
         expect(instance.state.checkedUserIdList).toEqual([1]);
     });
-
-    // it("confirmDisableCond test", () => {
-    //     const component = mount(manageCollectionMemberModal);
-
-    //     let wrapper = component.find("#modalOpenButton").hostNodes();
-    // })
 });

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.test.js
@@ -172,7 +172,7 @@ describe("ManageCollectionMemberModal test", () => {
     });
 
     // more tests should be implemented
-    it("should call deleteCollection when deleting", async () => {
+    it("should call deleteMembers when deleting", async () => {
         const component = mount(manageCollectionMemberModal);
         const instance = component.find(ManageCollectionMemberModal.WrappedComponent).instance();
         instance.setState({

--- a/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
+++ b/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
@@ -51,18 +51,20 @@ class TransferOwnershipModal extends Component {
 
     render() {
         let memberList = (<div />);
-        if (this.props.members.length > 0) {
-            memberList = this.props.members.map((user) => (
-                <UserEntry
-                  key={user.id}
-                  id={user.id}
-                  userName={user.username}
-                  userDesc={user.descrpition}
-                  isChecked={this.state.selectedUserId === user.id}
-                  checkhandler={() => this.checkHandler(user)}
-                  type="radio"
-                />
-            ));
+        if (this.props.me && this.props.members.length > 0) {
+            memberList = this.props.members
+                .filter((user) => user.id !== this.props.me.id)
+                .map((user) => (
+                    <UserEntry
+                      key={user.id}
+                      id={user.id}
+                      userName={user.username}
+                      userDesc={user.descrpition}
+                      isChecked={this.state.selectedUserId === user.id}
+                      checkhandler={() => this.checkHandler(user)}
+                      type="radio"
+                    />
+                ));
         }
 
         return (

--- a/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
+++ b/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
@@ -15,6 +15,12 @@ class TransferOwnershipModal extends Component {
             selectedUserId: -1,
             selectedUserName: "",
         };
+
+
+        this.clickOpenHandler = this.clickOpenHandler.bind(this);
+        this.clickCancelHandler = this.clickCancelHandler.bind(this);
+        this.checkHandler = this.checkHandler.bind(this);
+        this.transferDisableCond = this.transferDisableCond.bind(this);
     }
 
     clickOpenHandler = () => {
@@ -34,10 +40,6 @@ class TransferOwnershipModal extends Component {
             selectedUserId: user.id,
             selectedUserName: user.username,
         });
-    }
-
-    clickWarningConfirmAction = () => {
-        this.props.onTransferOwnership(this.props.thisCollection.id, this.state.selectedUserId);
     }
 
     transferDisableCond = () => {
@@ -82,7 +84,10 @@ class TransferOwnershipModal extends Component {
                           history={this.props.history}
                           openButtonText="Transfer to ..."
                           whatToWarnText={`Transfer "${this.props.thisCollection.title}" to "${this.state.selectedUserName}"`}
-                          whatActionWillBeDone={this.clickWarningConfirmAction}
+                          whatActionWillBeDone={() => this.props.onTransferOwnership(
+                              this.props.thisCollection.id,
+                              this.state.selectedUserId,
+                          )}
                           whereToGoAfterConfirm={`/collection_id=${this.props.thisCollection.id}`}
                           disableCondition={this.transferDisableCond()}
                           disableMessage="Select a user except you"

--- a/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
+++ b/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
@@ -20,7 +20,6 @@ class TransferOwnershipModal extends Component {
         this.clickOpenHandler = this.clickOpenHandler.bind(this);
         this.clickCancelHandler = this.clickCancelHandler.bind(this);
         this.checkHandler = this.checkHandler.bind(this);
-        this.transferDisableCond = this.transferDisableCond.bind(this);
     }
 
     clickOpenHandler = () => {
@@ -40,13 +39,6 @@ class TransferOwnershipModal extends Component {
             selectedUserId: user.id,
             selectedUserName: user.username,
         });
-    }
-
-    transferDisableCond = () => {
-        if (this.props.me) {
-            return this.state.selectedUserId <= 0 || this.state.selectedUserId === this.props.me.id;
-        }
-        return true;
     }
 
     render() {
@@ -83,16 +75,17 @@ class TransferOwnershipModal extends Component {
                     </Modal.Body>
                     <Modal.Footer>
                         <WarningModal
-                          history={this.props.history}
                           openButtonText="Transfer to ..."
                           whatToWarnText={`Transfer "${this.props.thisCollection.title}" to "${this.state.selectedUserName}"`}
                           whatActionWillBeDone={() => this.props.onTransferOwnership(
                               this.props.thisCollection.id,
                               this.state.selectedUserId,
                           )}
-                          whereToGoAfterConfirm={`/collection_id=${this.props.thisCollection.id}`}
-                          disableCondition={this.transferDisableCond()}
-                          disableMessage="Select a user except you"
+                          whatActionWillFollow={() => {
+                              this.props.history.replace(`/collection_id=${this.props.thisCollection.id}`);
+                          }}
+                          disableCondition={this.state.selectedUserId <= 0}
+                          disableMessage="Select a user"
                         />
                         <Button id="cancelButton" onClick={this.clickCancelHandler}>
                             Cancel

--- a/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.test.js
+++ b/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.test.js
@@ -14,7 +14,11 @@ const stubInitialState = {
     },
     auth: {
         signinStatus: signinStatus.SUCCESS,
-        me: { id: 1 },
+        me: {
+            id: 1,
+            username: "test1",
+            description: "asdf",
+        },
     },
     collection: {
         make: {
@@ -46,19 +50,20 @@ const stubInitialState = {
                 {
                     id: 1,
                     username: "test1",
-                    userDesc: "asdf",
+                    description: "asdf",
                 },
                 {
                     id: 2,
                     username: "test2",
-                    userDesc: "qwer",
+                    description: "qwer",
                 },
                 {
                     id: 3,
                     username: "test3",
-                    userDesc: "zxcv",
+                    description: "zxcv",
                 },
             ],
+            memberCount: 3,
             replies: [],
         },
     },
@@ -123,19 +128,40 @@ describe("TransferOwnershipModal test", () => {
 
     it("user entries test: should be rendered and handles checking", () => {
         const component = mount(transferModal);
+        const instance = component.find("TransferOwnershipModal").instance();
+
+        instance.setState({
+            members: [
+                {
+                    id: 1,
+                    username: "test1",
+                    description: "asdf",
+                },
+                {
+                    id: 2,
+                    username: "test2",
+                    description: "qwer",
+                },
+                {
+                    id: 3,
+                    username: "test3",
+                    description: "zxcv",
+                },
+            ],
+        });
+        component.update();
 
         // should be rendered
         let wrapper = component.find("#modalOpenButton").hostNodes();
         wrapper.simulate("click");
         wrapper = component.find(".entryItem");
-        expect(wrapper.length).toBe(3);
+        expect(wrapper.length).toBe(2); // excluding 'me'
 
         // should handle checking
         wrapper = component.find("#check").at(0);
         wrapper.simulate("change", { target: { checked: true } });
-        const instance = component.find("TransferOwnershipModal").instance();
-        expect(instance.state.selectedUserId).toBe(1);
-        expect(instance.state.selectedUserName).toBe("test1");
+        expect(instance.state.selectedUserId).toBe(2); // the first user of entries is "test2"
+        expect(instance.state.selectedUserName).toBe("test2");
     });
 
     // it("clickWarningConfirmAction should be called in WarningModal", () => {

--- a/frontend/src/components/Modal/WarningModal/WarningModal.js
+++ b/frontend/src/components/Modal/WarningModal/WarningModal.js
@@ -8,6 +8,10 @@ class WarningModal extends Component {
         this.state = {
             isModalOpen: false,
         };
+
+        this.clickOpenHandler = this.clickOpenHandler.bind(this);
+        this.clickConfirmHandler = this.clickConfirmHandler.bind(this);
+        this.clickCancelHandler = this.clickCancelHandler.bind(this);
     }
 
     clickOpenHandler = () => {
@@ -22,7 +26,8 @@ class WarningModal extends Component {
                     // after the job is done, should not return, so use replace
                     this.props.history.replace(this.props.whereToGoAfterConfirm);
                 }
-            });
+            })
+            .catch(() => {});
     }
 
     clickCancelHandler = () => {
@@ -94,7 +99,6 @@ WarningModal.propTypes = {
 
 WarningModal.defaultProps = {
     history: null,
-
     openButtonText: "",
     whatToWarnText: "",
     whatActionWillBeDone: () => {},

--- a/frontend/src/components/Modal/WarningModal/WarningModal.js
+++ b/frontend/src/components/Modal/WarningModal/WarningModal.js
@@ -22,9 +22,8 @@ class WarningModal extends Component {
         this.props.whatActionWillBeDone()
             .then(() => {
                 this.setState({ isModalOpen: false });
-                if (this.props.moveAfterDone) {
-                    // after the job is done, should not return, so use replace
-                    this.props.history.replace(this.props.whereToGoAfterConfirm);
+                if (this.props.whatActionWillFollow) {
+                    this.props.whatActionWillFollow();
                 }
             })
             .catch(() => {});
@@ -83,27 +82,20 @@ class WarningModal extends Component {
 export default WarningModal;
 
 WarningModal.propTypes = {
-    history: PropTypes.objectOf(PropTypes.any),
-
     // the following props should be given by a calling component
     openButtonText: PropTypes.string,
     whatToWarnText: PropTypes.string,
     whatActionWillBeDone: PropTypes.func,
-    // eslint-disable-next-line react/no-unused-prop-types
-    moveAfterDone: PropTypes.bool,
-    // eslint-disable-next-line react/no-unused-prop-types
-    whereToGoAfterConfirm: PropTypes.string,
+    whatActionWillFollow: PropTypes.func,
     disableCondition: PropTypes.bool,
     disableMessage: PropTypes.string,
 };
 
 WarningModal.defaultProps = {
-    history: null,
     openButtonText: "",
     whatToWarnText: "",
     whatActionWillBeDone: () => {},
-    moveAfterDone: true,
-    whereToGoAfterConfirm: "",
+    whatActionWillFollow: null,
     disableCondition: false,
     disableMessage: "",
 };

--- a/frontend/src/components/User/UserEntry/UserEntry.js
+++ b/frontend/src/components/User/UserEntry/UserEntry.js
@@ -8,14 +8,14 @@ const UserEntry = (props) => (
             ? (
                 <Form.Check
                   className="entryItem"
-                  id="check"
+                  id={`check-${props.userName}`}
                   type={props.type}
                   checked={props.isChecked}
                   onChange={props.checkhandler}
-                  label={props.userName}
                 />
             )
             : <div /> }
+        <h5>{props.userName}</h5>
     </Form.Row>
 );
 

--- a/frontend/src/components/User/UserEntry/UserEntry.js
+++ b/frontend/src/components/User/UserEntry/UserEntry.js
@@ -12,17 +12,18 @@ const UserEntry = (props) => (
                   type={props.type}
                   checked={props.isChecked}
                   onChange={props.checkhandler}
+                  label={props.userName}
                 />
             )
             : <div /> }
-        <h5>{props.userName}</h5>
-        <h5>{props.userDesc}</h5>
     </Form.Row>
 );
 
 UserEntry.propTypes = {
     userName: PropTypes.string,
+    /* eslint-disable react/no-unused-prop-types */
     userDesc: PropTypes.string,
+    /* eslint-enable react/no-unused-prop-types */
     type: PropTypes.string,
     isChecked: PropTypes.bool,
     checkhandler: PropTypes.func,

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -17,14 +17,12 @@ class CollectionDetail extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            // getCollectionStatus: collectionStatus.NONE,
             userCount: 0,
             likeCount: 0,
-            // eslint-disable-next-line react/no-unused-state
             paperCount: 0,
+            replyCount: 0,
             newReplyContent: "",
             isLiked: false,
-            // members: [],
             replies: [],
             papers: [],
             thisCollection: {},
@@ -46,6 +44,9 @@ class CollectionDetail extends Component {
                         thisCollection: this.props.selectedCollection,
                         isLiked: this.props.selectedCollection.liked,
                         likeCount: this.props.selectedCollection.count.likes,
+                        userCount: this.props.selectedCollection.count.users,
+                        replyCount: this.props.selectedCollection.count.replies,
+                        paperCount: this.props.selectedCollection.count.papers,
                     });
                 }
             });
@@ -60,6 +61,16 @@ class CollectionDetail extends Component {
                 });
             }).catch(() => {});
     }
+
+    /* eslint-disable react/no-did-update-set-state */
+    componentDidUpdate(prevProps) {
+        if (this.props.selectedCollection !== prevProps.selectedCollection) {
+            this.setState({
+                userCount: this.props.selectedCollection.count.users,
+            });
+        }
+    }
+    /* eslint-enable react/no-did-update-set-state */
 
     // clickRemovePaperButtonHandler(collection_id: number, paper_id: number)
     // : Call onRemoveCollectionPaper of CollectionDetail to remove the paper from the collection.
@@ -187,13 +198,13 @@ class CollectionDetail extends Component {
                     </div>
                     <div className="itemList">
                         <Tabs defaultActiveKey="paperTab" id="itemTabs">
-                            <Tab eventKey="paperTab" title="Papers">
+                            <Tab eventKey="paperTab" title={`Papers(${this.state.paperCount})`}>
                                 <div id="paperCards">
                                     <div id="paperCardsLeft">{paperCardsLeft}</div>
                                     <div id="paperCardsRight">{paperCardsRight}</div>
                                 </div>
                             </Tab>
-                            <Tab className="reply-tab" eventKey="replyTab" title="Replies">
+                            <Tab className="reply-tab" eventKey="replyTab" title={`Replies(${this.state.replyCount})`}>
                                 <div id="replies">
                                     <div id="createNewReply">
                                         <textarea

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -50,6 +50,7 @@ class CollectionDetail extends Component {
                     });
                 }
             });
+        this.props.onGetMembers(this.props.location.pathname.split("=")[1]);
         this.props.onGetCollectionPapers({ id: Number(this.props.location.pathname.split("=")[1]) })
             .then(() => {
                 this.setState({ papers: this.props.storedPapers });
@@ -181,7 +182,10 @@ class CollectionDetail extends Component {
                                     <div className="heart-image"><SVG name="heart" height="70%" width="70%" /></div>
                                     {this.state.likeCount}
                                 </Button>
-                                <InviteToCollectionModal openButtonName="Invite to ..." />
+                                <InviteToCollectionModal
+                                  openButtonName="Invite to ..."
+                                  members={this.props.members}
+                                />
                                 <Link to={`/collection_id=${this.props.selectedCollection.id}/manage`}>
                                     <Button id="manageButton">Manage</Button>
                                 </Link>
@@ -245,6 +249,7 @@ const mapStateToProps = (state) => ({
     unlikeCollectionStatus: state.collection.unlike.status,
     afterUnlikeCount: state.collection.unlike.count,
     replyList: state.reply.list,
+    members: state.collection.selected.members,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -252,14 +257,17 @@ const mapDispatchToProps = (dispatch) => ({
     onGetCollectionPapers: (collectionId) => dispatch(
         collectionActions.getCollectionPapers(collectionId),
     ),
+    onGetReplies: (collectionId) => dispatch(
+        replyActions.getRepliesByCollection(collectionId),
+    ),
+    onGetMembers: (collectionId) => dispatch(
+        collectionActions.getCollectionMembers(collectionId),
+    ),
     onLikeCollection: (collectionId) => dispatch(
         collectionActions.likeCollection(collectionId),
     ),
     onUnlikeCollection: (collectionId) => dispatch(
         collectionActions.unlikeCollection(collectionId),
-    ),
-    onGetReplies: (collectionId) => dispatch(
-        replyActions.getRepliesByCollection(collectionId),
     ),
     onMakeNewReply: (reply) => dispatch(
         replyActions.makeNewReplyCollection(reply),
@@ -282,8 +290,10 @@ CollectionDetail.propTypes = {
     onLikeCollection: PropTypes.func,
     onUnlikeCollection: PropTypes.func,
     onGetReplies: PropTypes.func,
+    onGetMembers: PropTypes.func,
     onMakeNewReply: PropTypes.func,
     replyList: PropTypes.objectOf(PropTypes.any),
+    members: PropTypes.arrayOf(PropTypes.any),
 };
 
 CollectionDetail.defaultProps = {
@@ -300,6 +310,8 @@ CollectionDetail.defaultProps = {
     onLikeCollection: () => {},
     onUnlikeCollection: () => {},
     onGetReplies: () => {},
+    onGetMembers: () => {},
     onMakeNewReply: () => {},
     replyList: {},
+    members: [],
 };

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -168,6 +168,15 @@ class CollectionDetail extends Component {
             />
         ));
 
+        let inviteModal = null;
+        if (this.props.me && this.props.members.map((x) => x.id).includes(this.props.me.id)) {
+            inviteModal = (
+                <InviteToCollectionModal
+                  openButtonName="Invite to ..."
+                  members={this.props.members}
+                />
+            );
+        }
         let manageButton = null;
         if (this.props.me && this.state.owner.id === this.props.me.id) {
             manageButton = (
@@ -210,10 +219,7 @@ class CollectionDetail extends Component {
                                     <div className="heart-image"><SVG name="heart" height="70%" width="70%" /></div>
                                     {this.state.likeCount}
                                 </Button>
-                                <InviteToCollectionModal
-                                  openButtonName="Invite to ..."
-                                  members={this.props.members}
-                                />
+                                {inviteModal}
                                 {manageButton}
                                 {this.state.thisCollection.amIMember ? editButton : <div />}
                             </div>

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -314,7 +314,7 @@ CollectionDetail.propTypes = {
 };
 
 CollectionDetail.defaultProps = {
-    me: null,
+    me: {},
     history: null,
     location: null,
     onGetCollection: null,

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -73,9 +73,9 @@ class CollectionDetail extends Component {
 
     /* eslint-disable react/no-did-update-set-state */
     componentDidUpdate(prevProps) {
-        if (this.props.selectedCollection !== prevProps.selectedCollection) {
+        if (this.props.memberCount !== prevProps.memberCount) {
             this.setState({
-                userCount: this.props.selectedCollection.count.users,
+                userCount: this.props.memberCount,
             });
         }
     }
@@ -179,6 +179,15 @@ class CollectionDetail extends Component {
             );
         }
 
+        let creationDate = "";
+        let modificationDate = "";
+        if (Object.keys(this.props.selectedCollection).length > 0) {
+            /* eslint-disable prefer-destructuring */
+            creationDate = this.props.selectedCollection.creation_date.split("T")[0];
+            modificationDate = this.props.selectedCollection.modification_date.split("T")[0];
+            /* eslint-enable prefer-destructuring */
+        }
+
         return (
             <div className="CollectionDetail">
                 <div className="CollectionDetailContent">
@@ -211,8 +220,8 @@ class CollectionDetail extends Component {
                         </div>
                         <div id="collectionDescription">
                             <div id="date">
-                                <div id="creationDate">Created: {this.state.thisCollection.creationDate}</div>
-                                <div id="lastUpdateDate">Last Update: {this.state.thisCollection.lastUpdateDate}</div>
+                                <div id="creationDate">Created: {creationDate}</div>
+                                <div id="lastUpdateDate">Last Update: {modificationDate}</div>
                             </div>
                             <p id="descriptionBox">{this.state.thisCollection.text}</p>
                         </div>
@@ -267,6 +276,7 @@ const mapStateToProps = (state) => ({
     afterUnlikeCount: state.collection.unlike.count,
     replyList: state.reply.list,
     members: state.collection.selected.members,
+    memberCount: state.collection.selected.memberCount,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -311,6 +321,7 @@ CollectionDetail.propTypes = {
     onMakeNewReply: PropTypes.func,
     replyList: PropTypes.objectOf(PropTypes.any),
     members: PropTypes.arrayOf(PropTypes.any),
+    memberCount: PropTypes.number,
 };
 
 CollectionDetail.defaultProps = {
@@ -331,4 +342,5 @@ CollectionDetail.defaultProps = {
     onMakeNewReply: () => {},
     replyList: {},
     members: [],
+    memberCount: 0,
 };

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -26,6 +26,7 @@ class CollectionDetail extends Component {
             replies: [],
             papers: [],
             thisCollection: {},
+            owner: {},
         };
         this.clickLikeButtonHandler = this.clickLikeButtonHandler.bind(this);
         this.clickUnlikeButtonHandler = this.clickUnlikeButtonHandler.bind(this);
@@ -50,7 +51,14 @@ class CollectionDetail extends Component {
                     });
                 }
             });
-        this.props.onGetMembers(this.props.location.pathname.split("=")[1]);
+        this.props.onGetMembers(this.props.location.pathname.split("=")[1])
+            .then(() => {
+                this.props.members.forEach((x) => {
+                    if (x.collection_user_type === "owner") {
+                        this.setState({ owner: x });
+                    }
+                });
+            });
         this.props.onGetCollectionPapers({ id: Number(this.props.location.pathname.split("=")[1]) })
             .then(() => {
                 this.setState({ papers: this.props.storedPapers });
@@ -160,6 +168,17 @@ class CollectionDetail extends Component {
             />
         ));
 
+        let manageButton = null;
+        if (this.props.me && this.state.owner.id === this.props.me.id) {
+            manageButton = (
+                <Button
+                  id="manageButton"
+                  href={`/collection_id=${this.props.selectedCollection.id}/manage`}
+                >Manage
+                </Button>
+            );
+        }
+
         return (
             <div className="CollectionDetail">
                 <div className="CollectionDetailContent">
@@ -186,9 +205,7 @@ class CollectionDetail extends Component {
                                   openButtonName="Invite to ..."
                                   members={this.props.members}
                                 />
-                                <Link to={`/collection_id=${this.props.selectedCollection.id}/manage`}>
-                                    <Button id="manageButton">Manage</Button>
-                                </Link>
+                                {manageButton}
                                 {this.state.thisCollection.amIMember ? editButton : <div />}
                             </div>
                         </div>

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.test.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.test.js
@@ -6,7 +6,7 @@ import { ConnectedRouter } from "connected-react-router";
 import { createBrowserHistory } from "history";
 import { collectionActions, replyActions } from "../../../store/actions";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
-import { getMockStore } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import CollectionDetail from "./CollectionDetail";
 
 
@@ -19,9 +19,6 @@ const makeCollectionDetail = (initialState, props = {}) => (
     </Provider>
 );
 /* eslint-enable react/jsx-props-no-spreading */
-
-const mockPromise = new Promise((resolve) => { resolve(); });
-const flushPromises = () => new Promise(setImmediate);
 
 describe("CollectionDetail Test", () => {
     let stubInitialState;

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
@@ -14,8 +14,6 @@ class CollectionManage extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            initName: "",
-            initDescription: "",
             collectionName: "",
             collectionDescription: "",
         };
@@ -29,9 +27,7 @@ class CollectionManage extends Component {
                     this.props.history.push("/main");
                 } else {
                     this.setState({
-                        initName: this.props.selectedCollection.title,
                         collectionName: this.props.selectedCollection.title,
-                        initDescription: this.props.selectedCollection.text,
                         collectionDescription: this.props.selectedCollection.text,
                     });
                 }
@@ -44,19 +40,28 @@ class CollectionManage extends Component {
             id: this.props.selectedCollection.id,
             title: this.state.collectionName,
             text: this.state.collectionDescription,
-        });
-        // message or popup that says "collection is updated" may need to be implemented
+        })
+            .then(() => {
+                this.props.onGetCollection({ id: this.props.selectedCollection.id });
+                // message or popup that says "collection is updated" may need to be implemented
+            });
     }
 
     render() {
+        let beforeName = null;
+        let beforeDescription = null;
+        if (this.props.selectedCollection) {
+            beforeName = this.props.selectedCollection.title;
+            beforeDescription = this.props.selectedCollection.text;
+        }
+
         return (
             <div className="CollectionManage">
                 <div className="EditCollectionInfo">
                     <div className="EditCollectionName">
                         <h3 id="editNameTag">Collection Name</h3>
-                        <textarea
+                        <input
                           id="editName"
-                          rows="1"
                           type="text"
                           value={this.state.collectionName}
                           onChange={(event) => this.setState({
@@ -81,8 +86,8 @@ class CollectionManage extends Component {
                           id="UpdateCollectionButton"
                           onClick={this.updateCollectionHandler}
                           disabled={this.state.collectionName === ""
-                            || (this.state.initName === this.state.collectionName
-                                && this.state.initDescription === this.state.collectionDescription)}
+                            || (beforeName === this.state.collectionName
+                                && beforeDescription === this.state.collectionDescription)}
                         >Update Collection
                         </Button>
                         <Link to={`/collection_id=${this.props.selectedCollection.id}`}>

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
@@ -32,7 +32,16 @@ class CollectionManage extends Component {
                     });
                 }
             });
-        this.props.onGetMembers(collectionId);
+        this.props.onGetMembers(collectionId)
+            .then(() => {
+                this.props.members.forEach((x) => {
+                    if (x.collection_user_type === "owner") {
+                        if (this.props.me.id !== x.id) {
+                            this.props.history.goBack();
+                        }
+                    }
+                });
+            });
     }
 
     updateCollectionHandler = () => {
@@ -133,8 +142,10 @@ class CollectionManage extends Component {
 }
 
 const mapStateToProps = (state) => ({
+    me: state.auth.me,
     collectionStatus: state.collection.selected.status,
     selectedCollection: state.collection.selected.collection,
+    members: state.collection.selected.members,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -151,11 +162,13 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(mapStateToProps, mapDispatchToProps)(CollectionManage);
 
 CollectionManage.propTypes = {
+    me: PropTypes.objectOf(PropTypes.any),
     history: PropTypes.objectOf(PropTypes.any),
     location: PropTypes.objectOf(PropTypes.any),
 
     selectedCollection: PropTypes.objectOf(PropTypes.any),
     collectionStatus: PropTypes.string,
+    members: PropTypes.arrayOf(PropTypes.any),
 
     onGetCollection: PropTypes.func,
     onUpdateCollectionInfo: PropTypes.func,
@@ -164,11 +177,13 @@ CollectionManage.propTypes = {
 };
 
 CollectionManage.defaultProps = {
+    me: {},
     history: null,
     location: null,
 
     selectedCollection: {},
     collectionStatus: collectionStatus.NONE,
+    members: [],
 
     onGetCollection: () => {},
     onUpdateCollectionInfo: () => {},

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
@@ -119,7 +119,7 @@ class CollectionManage extends Component {
                             to the other member of this collection.
                             WARNING: This action cannot be undone.
                         </h5>
-                        <TransferOwnershipModal />
+                        <TransferOwnershipModal history={this.props.history} />
                     </div>
                     <div className="DeleteCollection">
                         <h5 id="deleteCollectionText">Delete this collection.
@@ -131,7 +131,7 @@ class CollectionManage extends Component {
                           whatActionWillBeDone={() => this.props.onDeleteCollection(
                               this.props.selectedCollection.id,
                           )}
-                          whereToGoAfterConfirm="/collections"
+                          whatActionWillFollow={() => this.props.history.replace("/collections")}
                           history={this.props.history}
                         />
                     </div>

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
@@ -31,7 +31,8 @@ class CollectionManage extends Component {
                         collectionDescription: this.props.selectedCollection.text,
                     });
                 }
-            });
+            })
+            .catch(() => {});
         this.props.onGetMembers(collectionId)
             .then(() => {
                 this.props.members.forEach((x) => {
@@ -41,7 +42,8 @@ class CollectionManage extends Component {
                         }
                     }
                 });
-            });
+            })
+            .catch(() => {});
     }
 
     updateCollectionHandler = () => {
@@ -53,7 +55,8 @@ class CollectionManage extends Component {
             .then(() => {
                 this.props.onGetCollection({ id: this.props.selectedCollection.id });
                 // message or popup that says "collection is updated" may need to be implemented
-            });
+            })
+            .catch(() => {});
     }
 
     render() {

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.test.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.test.js
@@ -9,67 +9,6 @@ import { collectionStatus } from "../../../constants/constants";
 import { getMockStore } from "../../../test-utils/mocks";
 import { collectionActions } from "../../../store/actions";
 
-const stubInitialState = {
-    paper: {
-    },
-    auth: {
-        me: null,
-    },
-    collection: {
-        make: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        list: {
-            status: collectionStatus.NONE,
-            list: [],
-            error: null,
-        },
-        edit: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        delete: {
-            status: collectionStatus.NONE,
-            collection: {},
-            error: null,
-        },
-        selected: {
-            status: collectionStatus.NONE,
-            error: null,
-            collection: {
-                id: 1,
-                title: "test collection",
-                user: "test user",
-                numPapers: 14,
-                numReplies: 15,
-                count: {
-                    users: 0,
-                    papers: 0,
-                },
-            },
-            papers: [],
-            members: [],
-            replies: [],
-        },
-        like: {
-            status: collectionStatus.NONE,
-            count: 0,
-            error: null,
-        },
-        unlike: {
-            status: collectionStatus.NONE,
-            count: 0,
-            error: null,
-        },
-    },
-    user: {},
-    review: {},
-    reply: {},
-};
-
 const makeCollectionManage = (initialState) => (
     <Provider store={getMockStore(initialState)}>
         <ConnectedRouter history={createBrowserHistory()}>
@@ -80,8 +19,69 @@ const makeCollectionManage = (initialState) => (
 
 describe("CollectionManage test", () => {
     let collectionManage;
+    let stubInitialState;
 
     beforeEach(() => {
+        stubInitialState = {
+            paper: {
+            },
+            auth: {
+                me: null,
+            },
+            collection: {
+                make: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                list: {
+                    status: collectionStatus.NONE,
+                    list: [],
+                    error: null,
+                },
+                edit: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                delete: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: null,
+                },
+                selected: {
+                    status: collectionStatus.NONE,
+                    error: null,
+                    collection: {
+                        id: 1,
+                        title: "test collection",
+                        user: "test user",
+                        numPapers: 14,
+                        numReplies: 15,
+                        count: {
+                            users: 0,
+                            papers: 0,
+                        },
+                    },
+                    papers: [],
+                    members: [],
+                    replies: [],
+                },
+                like: {
+                    status: collectionStatus.NONE,
+                    count: 0,
+                    error: null,
+                },
+                unlike: {
+                    status: collectionStatus.NONE,
+                    count: 0,
+                    error: null,
+                },
+            },
+            user: {},
+            review: {},
+            reply: {},
+        };
         collectionManage = makeCollectionManage(stubInitialState);
     });
 
@@ -89,14 +89,28 @@ describe("CollectionManage test", () => {
         jest.clearAllMocks();
     });
 
-    it("should render without errors", () => {
+    it("should render without errors", async () => {
         const spyGetCollection = jest.spyOn(collectionActions, "getCollection")
             // eslint-disable-next-line no-unused-vars
             .mockImplementation(() => () => new Promise((resolve, reject) => { resolve(); }));
 
+        stubInitialState = {
+            ...stubInitialState,
+            collection: {
+                selected: {
+                    status: collectionStatus.SUCCESS,
+                    title: "test collection",
+                    text: "test description",
+                },
+            },
+        };
+
         const component = mount(collectionManage);
         const wrapper = component.find(".CollectionManage");
         expect(wrapper.length).toBe(1);
+
+        const flushPromises = () => new Promise(setImmediate);
+        await flushPromises();
 
         expect(spyGetCollection).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.test.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.test.js
@@ -6,7 +6,7 @@ import { ConnectedRouter } from "connected-react-router";
 import { createBrowserHistory } from "history";
 import CollectionManage from "./CollectionManage";
 import { collectionStatus } from "../../../constants/constants";
-import { getMockStore } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import { collectionActions } from "../../../store/actions";
 
 const makeCollectionManage = (initialState) => (
@@ -16,11 +16,6 @@ const makeCollectionManage = (initialState) => (
         </ConnectedRouter>
     </Provider>
 );
-
-/* eslint-disable no-unused-vars */
-const mockPromise = new Promise((resolve, reject) => { resolve(); });
-/* eslint-enable no-unused-vars */
-const flushPromises = () => new Promise(setImmediate);
 
 describe("CollectionManage test", () => {
     let collectionManage;

--- a/frontend/src/containers/User/UserList/UserList.test.js
+++ b/frontend/src/containers/User/UserList/UserList.test.js
@@ -17,6 +17,11 @@ const makeFollowerList = (initialState) => (
         <UserList history={mockHistory} location={{ pathname: "/profile_id=1/followers" }} />
     </Provider>
 );
+const makeWrongList = (initialState) => (
+    <Provider store={getMockStore(initialState)}>
+        <UserList history={mockHistory} location={{ pathname: "/profile_id=1/wrong" }} />
+    </Provider>
+);
 /* eslint-disable no-unused-vars */
 const mockPromise = new Promise((resolve, reject) => { resolve(); });
 /* eslint-enable no-unused-vars */
@@ -59,6 +64,12 @@ describe("<UserList />", () => {
         const followerWrapper = followerComponent.find(".user-list");
         expect(followerWrapper.length).toBe(1);
         expect(spyFollowersUser).toBeCalledTimes(1);
+    });
+
+    it("should not call anything when wrong pathname", () => {
+        mount(makeWrongList(stubInitialState));
+        expect(spyFollowingsUser).toBeCalledTimes(0);
+        expect(spyFollowersUser).toBeCalledTimes(0);
     });
 
     it("should make userCardsLeft and userCardsRight well", () => {

--- a/frontend/src/store/actions/collection/collection.js
+++ b/frontend/src/store/actions/collection/collection.js
@@ -181,7 +181,7 @@ export const removeCollectionPaper = (collectionsAndPaper) => (dispatch) => axio
 
 const addNewMembersSuccess = (count) => ({
     type: collectionConstants.ADD_COLLECTION_MEMBER,
-    count,
+    target: count.count,
 });
 
 const addNewMembersFailure = (error) => {
@@ -205,7 +205,7 @@ export const addNewMembers = (collectionId, userIdList) => (dispatch) => axios.p
 
 const deleteMembersSuccess = (count) => ({
     type: collectionConstants.DEL_COLLECTION_MEMBER,
-    count,
+    target: count.count,
 });
 
 const deleteMembersFailure = (error) => {

--- a/frontend/src/store/actions/collection/collection.js
+++ b/frontend/src/store/actions/collection/collection.js
@@ -178,6 +178,7 @@ export const removeCollectionPaper = (collectionsAndPaper) => (dispatch) => axio
     .then((res) => { dispatch(removeCollectionPaperSuccess(res.data)); })
     .catch((err) => { dispatch(removeCollectionPaperFailure(err)); });
 
+
 const addNewMembersSuccess = (count) => ({
     type: collectionConstants.ADD_COLLECTION_MEMBER,
     count,
@@ -201,6 +202,7 @@ export const addNewMembers = (collectionId, userIdList) => (dispatch) => axios.p
     .then((res) => { dispatch(addNewMembersSuccess(res.data)); })
     .catch((err) => { dispatch(addNewMembersFailure(err)); });
 
+
 const deleteMembersSuccess = (count) => ({
     type: collectionConstants.DEL_COLLECTION_MEMBER,
     count,
@@ -220,10 +222,10 @@ const deleteMembersFailure = (error) => {
     };
 };
 
-// FIXME : 400 bad request
-export const deleteMembers = (collectionId, userIdList) => (dispatch) => axios.delete("/api/user/collection", { id: collectionId, user_ids: userIdList })
+export const deleteMembers = (collectionId, userIdList) => (dispatch) => axios.delete("/api/user/collection", { params: { id: collectionId, user_ids: JSON.stringify(userIdList) } })
     .then((res) => { dispatch(deleteMembersSuccess(res.data)); })
     .catch((err) => { dispatch(deleteMembersFailure(err)); });
+
 
 // deleteCollection
 const deleteCollectionSuccess = (collection) => ({
@@ -294,6 +296,7 @@ const searchCollectionFailure = (error) => ({
 export const searchCollection = (searchWord) => (dispatch) => axios.get("/api/collection/search", { params: searchWord })
     .then((res) => dispatch(searchCollectionSuccess(res.data)))
     .catch((err) => dispatch(searchCollectionFailure(err)));
+
 
 // Get Collection Like
 const getCollectionLikeSuccess = (collections) => ({

--- a/frontend/src/store/actions/collection/collection.test.js
+++ b/frontend/src/store/actions/collection/collection.test.js
@@ -576,7 +576,7 @@ describe("collectionActions", () => {
 
         mockStore.dispatch(collectionActions.deleteMembers(1, [2, 3, 4]))
             .then(() => {
-                expect(spy).toHaveBeenCalledWith("/api/user/collection", { id: 1, user_ids: [2, 3, 4] });
+                expect(spy).toHaveBeenCalledWith("/api/user/collection", { params: { id: 1, user_ids: JSON.stringify([2, 3, 4]) } });
                 done();
             });
     });
@@ -595,7 +595,7 @@ describe("collectionActions", () => {
 
         mockStore.dispatch(collectionActions.deleteMembers(1, [2, 3, 4]))
             .then(() => {
-                expect(spy).toHaveBeenCalledWith("/api/user/collection", { id: 1, user_ids: [2, 3, 4] });
+                expect(spy).toHaveBeenCalledWith("/api/user/collection", { params: { id: 1, user_ids: JSON.stringify([2, 3, 4]) } });
                 done();
             });
     });
@@ -614,7 +614,7 @@ describe("collectionActions", () => {
 
         mockStore.dispatch(collectionActions.deleteMembers(1, [2, 3, 4]))
             .then(() => {
-                expect(spy).toHaveBeenCalledWith("/api/user/collection", { id: 1, user_ids: [2, 3, 4] });
+                expect(spy).toHaveBeenCalledWith("/api/user/collection", { params: { id: 1, user_ids: JSON.stringify([2, 3, 4]) } });
                 done();
             });
     });

--- a/frontend/src/store/actions/user/user.test.js
+++ b/frontend/src/store/actions/user/user.test.js
@@ -241,7 +241,7 @@ describe("userActions", () => {
             .mockImplementation(() => new Promise((_, reject) => {
                 const result = {
                     response: {
-                        status: 400,
+                        status: 422,
                         data: {},
                     },
                 };
@@ -296,7 +296,7 @@ describe("userActions", () => {
             .mockImplementation(() => new Promise((_, reject) => {
                 const result = {
                     response: {
-                        status: 400, // status code may need to be changed
+                        status: 422,
                         data: {},
                     },
                 };

--- a/frontend/src/store/reducers/collection/collection.js
+++ b/frontend/src/store/reducers/collection/collection.js
@@ -30,6 +30,7 @@ const initialState = {
         papers: [],
         members: [],
         replies: [],
+        memberCount: 0,
     },
     like: {
         status: collectionStatus.NONE,
@@ -125,8 +126,6 @@ const reducer = (state = initialState, action) => {
                 error: action.target,
             },
         };
-    // case collectionConstants.GET_COLLECTION_REPLIES:
-        // return { ...state };
     case collectionConstants.EDIT_COLLECTION:
         return {
             ...state,
@@ -178,10 +177,7 @@ const reducer = (state = initialState, action) => {
             selected: {
                 ...state.selected,
                 status: collectionStatus.SUCCESS,
-                collection: {
-                    ...state.selected.collection,
-                    user_counts: state.selected.collection.user_counts + action.count,
-                },
+                memberCount: action.target.users,
             },
         };
     case collectionConstants.ADD_COLLECTION_MEMBER_FAILURE_NOT_AUTHORIZED:
@@ -208,10 +204,7 @@ const reducer = (state = initialState, action) => {
             selected: {
                 ...state.selected,
                 status: collectionStatus.SUCCESS,
-                collection: {
-                    ...state.selected.collection,
-                    user_counts: state.selected.collection.user_counts - action.count,
-                },
+                memberCount: action.target.users,
             },
         };
     case collectionConstants.DEL_COLLECTION_MEMBER_FAILURE_NOT_AUTHORIZED:

--- a/frontend/src/store/reducers/collection/collection.js
+++ b/frontend/src/store/reducers/collection/collection.js
@@ -25,12 +25,12 @@ const initialState = {
     },
     selected: {
         status: collectionStatus.NONE,
-        error: null,
         collection: {},
+        error: null,
         papers: [],
         members: [],
-        replies: [],
         memberCount: 0,
+        replies: [],
     },
     like: {
         status: collectionStatus.NONE,

--- a/frontend/src/store/reducers/collection/collection.test.js
+++ b/frontend/src/store/reducers/collection/collection.test.js
@@ -25,12 +25,11 @@ const stubInitialState = {
     },
     selected: {
         status: collectionStatus.NONE,
+        collection: {},
         error: null,
-        collection: {
-            user_counts: 5,
-        },
         papers: [],
         members: [],
+        memberCount: 0,
         replies: [],
     },
     like: {
@@ -202,10 +201,10 @@ describe("Collection reducer", () => {
     it("should return add_collection_member", () => {
         const newState = reducer(stubInitialState, {
             type: collectionConstants.ADD_COLLECTION_MEMBER,
-            count: 2,
+            target: { users: 7 },
         });
         expect(newState.selected.status).toBe(collectionStatus.SUCCESS);
-        expect(newState.selected.collection.user_counts).toBe(7);
+        expect(newState.selected.memberCount).toBe(7);
     });
 
     it("should return add_collection_member_failure_not_authorized", () => {
@@ -229,10 +228,10 @@ describe("Collection reducer", () => {
     it("should return del_collection_member", () => {
         const newState = reducer(stubInitialState, {
             type: collectionConstants.DEL_COLLECTION_MEMBER,
-            count: 2,
+            target: { users: 3 },
         });
         expect(newState.selected.status).toBe(collectionStatus.SUCCESS);
-        expect(newState.selected.collection.user_counts).toBe(3);
+        expect(newState.selected.memberCount).toBe(3);
     });
 
     it("should return del_collection_member_failure_not_authorized", () => {

--- a/frontend/src/test-utils/mocks.js
+++ b/frontend/src/test-utils/mocks.js
@@ -44,3 +44,9 @@ export const mockComponent = (componentName) => (props) => (
     <div className={componentName} {...props} />
     /* eslint-enable react/jsx-props-no-spreading */
 );
+
+/* eslint-disable no-unused-vars */
+export const mockPromise = new Promise((resolve, reject) => { resolve(); });
+/* eslint-enable no-unused-vars */
+
+export const flushPromises = () => new Promise(setImmediate);


### PR DESCRIPTION
Related Issue: #119 
This PR will resolve #119 issue.


# Major changes
This PR solve problems mentioned in #94 PR and several other problems about collection features.

- Now, 'Delete /api/user/collection' is working. Related frontend features is activated.

- GET /api/user/collection also gives info about collection_user_type(owner or member).

- Transferring ownership doesn't raise errors(related with warning modals).

- When users create a new collection without description on Collection List Page, error is not raised now.

- If a user is not the owner of a certain collection, she or he can't see 'Manage' button on Collection Detail Page. If she or he tries to access the Collection Manage Page, the page will redirect her or him to the Collection Detail Page.
![스크린샷 2019-11-26 04 36 12](https://user-images.githubusercontent.com/35535636/69571967-7fe84c80-1006-11ea-8778-acb33169a1ee.png)

- Now, all members can invite other users to their collections. It means all users can see 'Invite' button on the Collection Detail Page and other users can't.

- After updating members of collections on a certain page, now the page itself reflect the change right after without needs for refresh.

- After creating collections, Collection List Page already reflects the newly added collection.

- Collection Detail reflect creation/modification date and the number of members of the collection.

- I set Django time zone as `Asia/Seoul`.

- Lists of users on InviteToCollectionModal excludes users who are already members of the collection.

- Lists of members on TransferOwnershipModal and ManageCollectionMemberModal(removeMode) excludes the user(me).

- Action and reducer codes about adding and removing members properly mange its `action.target`(memberCount).

- **I solved the async test problems mentioned in #51, #55, #71, #76, #85, etc. Please improve your tests!**

# Minor changes
- `__pack_collections()` of `utils/collections/utils.py` in backend codes now generates a response without 'contains_paper' key and value if it isn't needed.

- Minor code refactoring(especially WarningModal)

- Fixed inappropriate key(field) names of test codes.

- UserEntry doesn't show the users' description.


### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
