### PR TITLE
Fix Bugs about Calling Search APIs twice and 'Paper' button on ReviewDetail page

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -13,17 +13,18 @@
     font-size: 150%;
     font-style: oblique;
     padding: 1%;
-    margin-right: 10%;
+    margin-right: 5%;
 }
 
 .header .search {
+    width: 50%;
     display: flex;
     align-items: flex-start;
 }
 
 .header .search .search-input {
     /* margin-left:18%; */
-    width: 500px;
+    width: 100%;
     background:rgb(242,243,247);
 }
 
@@ -31,15 +32,30 @@
     margin-left: auto;
     display: flex;
     flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: 3%;
+}
+
+.header .buttons .dropdown-notification {
+    display: inline-block;
+    flex-direction: row;
+    justify-content: space-around;
+}
+
+.header .buttons .dropdown-account {
+    display: inline-block;
+    flex-direction: row;
+    justify-content: space-around;
 }
 
 .header .buttons .notification-button {
-    margin-right: 20px;
+    margin-right: 5%;
  }
 
  .header .buttons .notification-menu {
     height: 200px;
-    width: 200%;
+    width: 250%;
     overflow-y: scroll;
 }
 
@@ -64,7 +80,7 @@
 }
 
 .header .buttons .myaccount-button {
-   margin-right: 20px;
+    margin-left: 5%;
 }
 
 .header .buttons .myaccount-menu {

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -32,11 +32,11 @@ class Header extends Component {
             .catch(() => {});
     }
 
-    keyPressHandler = () => {
+    keyPressHandler = (e) => {
         // FIXME: For now, there is an issue that if users press enter, search APIs are called twice
-        // if (this.state.searchWord && e.charCode === 13) {
-        //    this.props.history.push(`/search=${this.state.searchWord}`);
-        // }
+        if (this.state.searchWord && e.charCode === 13) {
+            this.props.history.push(`/search=${this.state.searchWord}`);
+        }
     };
 
     // for search input change
@@ -124,11 +124,11 @@ class Header extends Component {
             <div>
                 <Navbar className="header">
                     <Nav.Link className="logo" href="/main">PapersFeed</Nav.Link>
-                    <Form inline className="search">
+                    <div className="search"> {/* if 'Form', 'enter' triggers calls twice} */}
                         <Form.Control
                           className="search-input"
-                          type="search"
-                          placeholder="Search (by clicking 'Search' button)"
+                          type="text"
+                          placeholder="Search"
                           value={this.state.searchWord}
                           onChange={this.handleChange}
                           onKeyPress={this.keyPressHandler}
@@ -139,15 +139,15 @@ class Header extends Component {
                           disabled={!this.state.searchWord}
                         >Search
                         </Button>
-                    </Form>
+                    </div>
                     <div className="buttons">
-                        <Dropdown>
+                        <Dropdown className="dropdown-notification">
                             <Dropdown.Toggle title="notification" className="notification-button">{notificationLabel}</Dropdown.Toggle>
                             <Dropdown.Menu className="notification-menu">
                                 {notifications}
                             </Dropdown.Menu>
                         </Dropdown>
-                        <Dropdown>
+                        <Dropdown className="dropdown-account">
                             <Dropdown.Toggle title="myaccount" className="myaccount-button">My Account</Dropdown.Toggle>
                             <Dropdown.Menu className="myaccount-menu">
                                 <Dropdown.Header className="username-header">{username}</Dropdown.Header>

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -33,7 +33,6 @@ class Header extends Component {
     }
 
     keyPressHandler = (e) => {
-        // FIXME: For now, there is an issue that if users press enter, search APIs are called twice
         if (this.state.searchWord && e.charCode === 13) {
             this.props.history.push(`/search=${this.state.searchWord}`);
         }

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -238,6 +238,6 @@ describe("<Header />", () => {
         expect(mockHistory.push).toHaveBeenCalledTimes(0);
 
         wrapper.simulate("keypress", { charCode: 13 });
-        expect(mockHistory.push).toHaveBeenCalledTimes(0);
+        expect(mockHistory.push).toHaveBeenCalledTimes(1);
     });
 });

--- a/frontend/src/components/Paper/PaperCard/PaperCard.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.js
@@ -41,10 +41,10 @@ class PaperCard extends Component {
         }
     }
 
-    processKeywords = (type) => this.props.keywords.slice(0, 10).filter(
-        (keyword) => keyword.type === type,
-    ).sort(
+    processKeywords = (type) => this.props.keywords.sort(
         (a, b) => a.id - b.id,
+    ).slice(0, 10).filter(
+        (keyword) => keyword.type === type,
     ).map(
         (keyword) => (
             <Button

--- a/frontend/src/containers/History/History.css
+++ b/frontend/src/containers/History/History.css
@@ -16,7 +16,7 @@
 }
 
 .item-list .paper-cards {
-    width: 80%;
+    width: 100%;
     height: 100%;
     margin: 15px;
     
@@ -43,7 +43,7 @@
 }
 
 .item-list .collection-cards {
-    width: 80%;
+    width: 100%;
     height: 100%;
     margin: 15px;
     
@@ -70,7 +70,7 @@
 }
 
 .item-list .review-cards {
-    width: 80%;
+    width: 100%;
     height: 100%;
     margin: 15px;
     

--- a/frontend/src/containers/Review/ReviewDetail/ReviewDetail.js
+++ b/frontend/src/containers/Review/ReviewDetail/ReviewDetail.js
@@ -159,6 +159,7 @@ class ReviewDetail extends Component {
                                     {this.props.me && this.state.author.id === this.props.me.id ? (
                                         <Button className="delete-button" onClick={this.clickDeleteButtonHandler}>Delete</Button>
                                     ) : null}
+                                    <Button className="paper-button" variant="secondary" href={`/paper_id=${this.state.paperId}`}>Paper</Button>
                                 </div>
                                 <Form className="new-reply">
                                     <Form.Label className="username">{this.state.user.username}</Form.Label>

--- a/frontend/src/containers/User/ProfileDetail/ProfileDetail.js
+++ b/frontend/src/containers/User/ProfileDetail/ProfileDetail.js
@@ -188,13 +188,13 @@ class ProfileDetail extends Component {
                     </div>
                     <div className="itemTabSection">
                         <Tabs defaultActiveKey="collectionTab" id="itemTabs">
-                            <Tab eventKey="collectionTab" title="Collections">
+                            <Tab eventKey="collectionTab" title={`Collection(${this.state.collections.length})`}>
                                 <div id="collectionCards">
                                     <div id="collectionCardsLeft">{collectionCardsLeft}</div>
                                     <div id="collectionCardsRight">{collectionCardsRight}</div>
                                 </div>
                             </Tab>
-                            <Tab eventKey="reviewTab" title="Reviews">
+                            <Tab eventKey="reviewTab" title={`Review(${this.state.reviews.length})`}>
                                 <div id="reviewCards">
                                     <div id="reviewCardsLeft">{reviewCardsLeft}</div>
                                     <div id="reviewCardsRight">{reviewCardsRight}</div>

--- a/frontend/src/containers/User/UserList/UserList.js
+++ b/frontend/src/containers/User/UserList/UserList.js
@@ -15,7 +15,6 @@ class UserList extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            id: this.props.match.params.id,
             users: [],
         };
 
@@ -25,7 +24,7 @@ class UserList extends Component {
     componentDidMount() {
         this._isMounted = true;
         if (this.props.mode === "followings") {
-            this.props.onFollowingUser({ id: this.state.id })
+            this.props.onFollowingUser({ id: this.props.match.params.id })
                 .then(() => {
                     if (this.props.userStatus === userStatus.USER_NOT_EXIST) {
                         this.props.history.push("/main");
@@ -35,7 +34,7 @@ class UserList extends Component {
                     }
                 });
         } else if (this.props.mode === "followers") {
-            this.props.onFollowerUser({ id: this.state.id })
+            this.props.onFollowerUser({ id: this.props.match.params.id })
                 .then(() => {
                     if (this.props.userStatus === userStatus.USER_NOT_EXIST) {
                         this.props.history.push("/main");
@@ -45,7 +44,7 @@ class UserList extends Component {
                     }
                 });
         } else if (this.props.mode === "members") {
-            this.props.onGetMembers(this.state.id)
+            this.props.onGetMembers(this.props.match.params.id)
                 .then(() => {
                     if (this.props.getMembersStatus === collectionStatus.FAILURE) {
                         this.props.history.push("/main");


### PR DESCRIPTION
Related Issue: #118 
This PR will resolve #118 issue.

# Major changes
Now, the search APIs are called only once, even though pressing 'enter' key on any pages. So, I enabled searching with 'enter' key.

Also, only on the deployed site, there was bug that UserLists sometimes crash due to 'id' of null value. I solved this problem.

In addition, I added 'Paper' button on ReviewDetail page. If users click it, they will be redirected to the related PaperDetail page.

<img width="1053" alt="스크린샷 2019-11-29 13 14 11" src="https://user-images.githubusercontent.com/35535636/69843279-23a55700-12aa-11ea-8fdf-79029ca81f40.png">


# Minor changes
Minor CSS works.

Also, the numbers of papers and reviews are now shown on ProfileDetail page. However, its implementation is naive. It just reflects the lengths of papers and reviews of current state. So, if users have more than pagination count, the counts will be only the pagination count, not real users' count. So, related backend works(giving real counts of papers and reviews of the given user) should be done.

<img width="1033" alt="스크린샷 2019-11-29 13 28 58" src="https://user-images.githubusercontent.com/35535636/69843842-84ce2a00-12ac-11ea-966b-4c55a503dcfa.png">


### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
