### PR TITLE
Subscription Feed (Frontend)

### DIFF
--- a/backend/papersfeed/tests/papers/tests_paper.py
+++ b/backend/papersfeed/tests/papers/tests_paper.py
@@ -386,7 +386,7 @@ class PaperTestCase(TestCase):
 
         mock_get.return_value = Mock(
             text=stub_xml.read(),
-            status_code=200
+            status_code=403
         )
 
         # NOTE: for now, actually this API is not called

--- a/backend/papersfeed/utils/likes/utils.py
+++ b/backend/papersfeed/utils/likes/utils.py
@@ -50,10 +50,9 @@ def insert_like_paper(args):
     )
 
     # store an action for subscription feed
-    req_user = User.objects.get(id=request_user.id)
     paper = Paper.objects.get(id=paper_id)
     Subscription.objects.create(
-        actor=req_user,
+        actor=request_user,
         verb="liked",
         action_object=paper,
     )
@@ -138,9 +137,8 @@ def insert_like_review(args):
     review_author = User.objects.get(id=review.user_id)
 
     # store an action for subscription feed
-    req_user = User.objects.get(id=request_user.id)
     Subscription.objects.create(
-        actor=req_user,
+        actor=request_user,
         verb="liked",
         action_object=review,
     )

--- a/backend/papersfeed/utils/subscriptions/utils.py
+++ b/backend/papersfeed/utils/subscriptions/utils.py
@@ -24,7 +24,6 @@ def select_subscriptions(args):
     # pylint: enable=line-too-long
     # Notification QuerySet
     subscription_queryset = Subscription.objects.filter(Q(actor__in=followings_queryset))
-
     subscriptions = get_results_from_queryset(subscription_queryset, 20, page_number)
 
     # is_finished
@@ -44,19 +43,19 @@ def __pack_subscriptions(subscriptions, request_user):
                 paper = get_papers(Q(id=subscription.action_object.id), request_user, 1)[0]
                 action_object = {
                     constants.TYPE: 'paper',
-                    constants.CONTENT: paper,
+                    constants.CONTENT: paper[0],
                 }
             elif action_object_type == 'collection':
                 collection = get_collections(Q(id=subscription.action_object.id), request_user, 1)[0]
                 action_object = {
                     constants.TYPE: 'collection',
-                    constants.CONTENT: collection,
+                    constants.CONTENT: collection[0],
                 }
             elif action_object_type == 'review':
                 review = get_reviews(Q(id=subscription.action_object.id), request_user, 1)[0]
                 action_object = {
                     constants.TYPE: 'review',
-                    constants.CONTENT: review,
+                    constants.CONTENT: review[0],
                 }
             else:
                 raise AttributeError

--- a/frontend/src/components/Collection/CollectionCard/CollectionCard.css
+++ b/frontend/src/components/Collection/CollectionCard/CollectionCard.css
@@ -7,6 +7,36 @@
     text-align: left;
 }
 
+#headerSubscriptionTarget {
+    display: inline-flex;
+    flex-direction: row;
+    /* align-items: center; */
+}
+
+#headerSubscription {
+    display: inline-flex;
+    flex-direction: row;
+    /* align-items: center; */
+}
+
+#headerLine {
+    display: inline-flex;
+    flex-direction: row;
+    /* align-items: center; */
+}
+
+.actorLink {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+    font-size: 120%;
+}
+
+.verb {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+
+}
+
 .collection .body {
     padding: 10%;
 }

--- a/frontend/src/components/Collection/CollectionCard/CollectionCard.js
+++ b/frontend/src/components/Collection/CollectionCard/CollectionCard.js
@@ -42,8 +42,8 @@ class CollectionCard extends Component {
             if (this.props.subscription) {
                 header = (
                     <Card.Header id="headerSubscription">
-                        <Card.Link href={`/collection_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
-                        <h5>{` ${this.props.verb} this collection.`}</h5>
+                        <Card.Link className="actorLink" href={`/collection_id=${this.props.id}`}>{this.props.actor.username}</Card.Link>
+                        <h5 className="verb">{` ${this.props.verb} this collection.`}</h5>
                     </Card.Header>
                 );
             } else {

--- a/frontend/src/components/Collection/CollectionCard/CollectionCard.js
+++ b/frontend/src/components/Collection/CollectionCard/CollectionCard.js
@@ -39,7 +39,17 @@ class CollectionCard extends Component {
     render() {
         let header = null;
         if (this.props.headerExists) {
-            header = <Card.Header>{`${this.props.user} ${this.props.source} this collection.`}</Card.Header>;
+            if (this.props.subscription) {
+                header = (
+                    <Card.Header id="headerSubscription">
+                        <Card.Link href={`/collection_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
+                        <h5>{` ${this.props.verb} this collection.`}</h5>
+                    </Card.Header>
+                );
+            } else {
+                // legacy code: this line may not be needed
+                header = <Card.Header id="header">{`${this.props.user} ${this.props.source} this collection.`}</Card.Header>;
+            }
         }
         return (
             <div className="wrapper">
@@ -100,6 +110,11 @@ CollectionCard.propTypes = {
     afterUnlikeCount: PropTypes.number,
     onLikeCollection: PropTypes.func,
     onUnlikeCollection: PropTypes.func,
+    subscription: PropTypes.bool,
+    actor: PropTypes.objectOf(PropTypes.any),
+    verb: PropTypes.string,
+    // eslint-disable-next-line react/no-unused-prop-types
+    target: PropTypes.objectOf(PropTypes.any),
 };
 
 CollectionCard.defaultProps = {
@@ -117,4 +132,8 @@ CollectionCard.defaultProps = {
     afterUnlikeCount: 0,
     onLikeCollection: () => {},
     onUnlikeCollection: () => {},
+    subscription: false,
+    actor: {},
+    verb: "",
+    target: {},
 };

--- a/frontend/src/components/Collection/CollectionCard/CollectionCard.test.js
+++ b/frontend/src/components/Collection/CollectionCard/CollectionCard.test.js
@@ -90,7 +90,25 @@ describe("<CollectionCard />", () => {
     it("if headerExists is false, then header should not exist", () => {
         collectionCard = makeCollectionCard(stubInitialState, { headerExists: false });
         const component = mount(collectionCard);
-        const wrapper = component.find(".header");
+        let wrapper = component.find("#headerSubscription").hostNodes();
         expect(wrapper.length).toBe(0);
+        wrapper = component.find("#header").hostNodes();
+        expect(wrapper.length).toBe(0);
+    });
+
+    it("if headerExists and not subscription, then header should exist", () => {
+        collectionCard = makeCollectionCard(stubInitialState, { headerExists: true });
+        const component = mount(collectionCard);
+        const wrapper = component.find("#header").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("if headerExists and subscription, then subscription header should exist", () => {
+        collectionCard = makeCollectionCard(stubInitialState, {
+            headerExists: true, subscription: true,
+        });
+        const component = mount(collectionCard);
+        const wrapper = component.find("#headerSubscription").hostNodes();
+        expect(wrapper.length).toBe(1);
     });
 });

--- a/frontend/src/components/Paper/PaperCard/PaperCard.css
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.css
@@ -2,6 +2,32 @@
     padding-bottom: 10%;
 }
 
+#headerSubscriptionTarget {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+#headerSubscription {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+#headerLine {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+.actorLink {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+    font-size: 120%;
+}
+
+.verb {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+}
+
 .paper {
     width: 90%;
     text-align: left;

--- a/frontend/src/components/Paper/PaperCard/PaperCard.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.js
@@ -81,8 +81,27 @@ class PaperCard extends Component {
     render() {
         let header = null;
         if (this.props.headerExists) {
-            if (this.props.paperSource) {
-                header = <Card.Header>{`from ${this.props.paperSource}`}</Card.Header>;
+            if (this.props.subscription) {
+                if (Object.keys(this.props.target).length !== 0) {
+                    header = (
+                        <Card.Header id="headerSubscriptionTarget">
+                            <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
+                            <h5>{` ${this.props.verb} this paper on `}</h5>
+                            <Card.Link href={`/collection_id=${this.props.target.content.id}`} className="text">
+                                {`${this.props.target.content.title}.`}
+                            </Card.Link>
+                        </Card.Header>
+                    );
+                } else {
+                    header = (
+                        <Card.Header id="headerSubscription">
+                            <Card.Link href={`/profile_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
+                            <h5>{` ${this.props.verb} this paper.`}</h5>
+                        </Card.Header>
+                    );
+                }
+            } else if (this.props.paperSource) {
+                header = <Card.Header id="header">{`from ${this.props.paperSource}`}</Card.Header>;
             }
         }
         let addButton = null;
@@ -152,6 +171,10 @@ PaperCard.propTypes = {
     afterUnlikeCount: PropTypes.number,
     onLikePaper: PropTypes.func,
     onUnlikePaper: PropTypes.func,
+    subscription: PropTypes.bool,
+    actor: PropTypes.objectOf(PropTypes.any),
+    verb: PropTypes.string,
+    target: PropTypes.objectOf(PropTypes.any),
 };
 
 PaperCard.defaultProps = {
@@ -171,4 +194,8 @@ PaperCard.defaultProps = {
     afterUnlikeCount: 0,
     onLikePaper: () => {},
     onUnlikePaper: () => {},
+    subscription: false,
+    actor: {},
+    verb: "",
+    target: {},
 };

--- a/frontend/src/components/Paper/PaperCard/PaperCard.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.js
@@ -83,8 +83,8 @@ class PaperCard extends Component {
         if (this.props.headerExists) {
             if (this.props.subscription) {
                 const headerLine = (
-                    <div>
-                        <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
+                    <div id="headerLine">
+                        <Card.Link href={`/profile_id=${this.props.actor.id}`}>{this.props.actor.username}</Card.Link>
                         <h5>{` ${this.props.verb} this paper on `}</h5>
                     </div>
                 );
@@ -92,7 +92,7 @@ class PaperCard extends Component {
                     header = (
                         <Card.Header id="headerSubscriptionTarget">
                             {headerLine}
-                            <Card.Link href={`/collection_id=${this.props.target.content.id}`} className="text">
+                            <Card.Link href={`/collection_id=${this.props.target.content.id}`}>
                                 {`${this.props.target.content.title}.`}
                             </Card.Link>
                         </Card.Header>
@@ -105,7 +105,7 @@ class PaperCard extends Component {
                     );
                 }
             } else if (this.props.paperSource) {
-                header = <Card.Header id="header">{`from ${this.props.paperSource}`}</Card.Header>;
+                header = <Card.Header id="header" className="CardHeader">{`from ${this.props.paperSource}`}</Card.Header>;
             }
         }
         let addButton = null;

--- a/frontend/src/components/Paper/PaperCard/PaperCard.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.js
@@ -82,11 +82,16 @@ class PaperCard extends Component {
         let header = null;
         if (this.props.headerExists) {
             if (this.props.subscription) {
+                const headerLine = (
+                    <div>
+                        <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
+                        <h5>{` ${this.props.verb} this paper on `}</h5>
+                    </div>
+                );
                 if (Object.keys(this.props.target).length !== 0) {
                     header = (
                         <Card.Header id="headerSubscriptionTarget">
-                            <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
-                            <h5>{` ${this.props.verb} this paper on `}</h5>
+                            {headerLine}
                             <Card.Link href={`/collection_id=${this.props.target.content.id}`} className="text">
                                 {`${this.props.target.content.title}.`}
                             </Card.Link>
@@ -95,8 +100,7 @@ class PaperCard extends Component {
                 } else {
                     header = (
                         <Card.Header id="headerSubscription">
-                            <Card.Link href={`/profile_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
-                            <h5>{` ${this.props.verb} this paper.`}</h5>
+                            {headerLine}
                         </Card.Header>
                     );
                 }

--- a/frontend/src/components/Paper/PaperCard/PaperCard.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.js
@@ -82,16 +82,12 @@ class PaperCard extends Component {
         let header = null;
         if (this.props.headerExists) {
             if (this.props.subscription) {
-                const headerLine = (
-                    <div id="headerLine">
-                        <Card.Link href={`/profile_id=${this.props.actor.id}`}>{this.props.actor.username}</Card.Link>
-                        <h5>{` ${this.props.verb} this paper on `}</h5>
-                    </div>
-                );
+                const actorLink = (<Card.Link className="actorLink" href={`/profile_id=${this.props.actor.id}`}>{this.props.actor.username}</Card.Link>);
                 if (Object.keys(this.props.target).length !== 0) {
                     header = (
                         <Card.Header id="headerSubscriptionTarget">
-                            {headerLine}
+                            {actorLink}
+                            <h5 className="verb">{` ${this.props.verb} this paper on `}</h5>
                             <Card.Link href={`/collection_id=${this.props.target.content.id}`}>
                                 {`${this.props.target.content.title}.`}
                             </Card.Link>
@@ -100,12 +96,13 @@ class PaperCard extends Component {
                 } else {
                     header = (
                         <Card.Header id="headerSubscription">
-                            {headerLine}
+                            {actorLink}
+                            <h5 className="verb">{` ${this.props.verb} this paper.`}</h5>
                         </Card.Header>
                     );
                 }
             } else if (this.props.paperSource) {
-                header = <Card.Header id="header" className="CardHeader">{`from ${this.props.paperSource}`}</Card.Header>;
+                header = <Card.Header id="header">{`from ${this.props.paperSource}`}</Card.Header>;
             }
         }
         let addButton = null;

--- a/frontend/src/components/Paper/PaperCard/PaperCard.test.js
+++ b/frontend/src/components/Paper/PaperCard/PaperCard.test.js
@@ -80,8 +80,37 @@ describe("<PaperCard />", () => {
     it("if headerExists is false, then header should not exist", () => {
         paperCard = makePaperCard(stubInitialState, { headerExists: false });
         const component = mount(paperCard);
-        const wrapper = component.find(".header");
+        let wrapper = component.find("#header").hostNodes();
         expect(wrapper.length).toBe(0);
+        wrapper = component.find("#headerSubscription").hostNodes();
+        expect(wrapper.length).toBe(0);
+        wrapper = component.find("#headerSubscriptionTarget").hostNodes();
+        expect(wrapper.length).toBe(0);
+    });
+
+    it("if headerExists && paperSource, then header should exist", () => {
+        paperCard = makePaperCard(stubInitialState, { headerExists: true, subscription: false, paperSource: "source" });
+        const component = mount(paperCard);
+        const wrapper = component.find("#header").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("if headerExists && subscription, then subscription header should exist", () => {
+        paperCard = makePaperCard(stubInitialState, {
+            headerExists: true, subscription: true, target: {},
+        });
+        const component = mount(paperCard);
+        const wrapper = component.find("#headerSubscription").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("if headerExists && subscription && target, then subscription header with target should exist", () => {
+        paperCard = makePaperCard(stubInitialState, {
+            headerExists: true, subscription: true, target: { content: { id: 1 } },
+        });
+        const component = mount(paperCard);
+        const wrapper = component.find("#headerSubscriptionTarget").hostNodes();
+        expect(wrapper.length).toBe(1);
     });
 
     it("if addButtonExists is true, then addButton should exist", () => {

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.css
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.css
@@ -7,6 +7,33 @@
     text-align: left;
 }
 
+
+#headerSubscriptionTarget {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+#headerSubscription {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+#headerLine {
+    display: inline-flex;
+    flex-direction: row;
+}
+
+.actorLink {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+    font-size: 120%;
+}
+
+.verb {
+    /* This is interval between texts: DO NOT MODIFY IT */
+    margin-right: 5px;
+}
+
 .review .body {
     padding-bottom: 10%;
 }

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -39,7 +39,29 @@ class ReviewCard extends Component {
     render() {
         let header = null;
         if (this.props.headerExists) {
-            header = <Card.Header className="header">{`${this.props.user} ${this.props.source} this review`}</Card.Header>;
+            if (this.props.subscription) {
+                if (Object.keys(this.props.target).length !== 0) {
+                    header = (
+                        <Card.Header id="headerSubscriptionTarget">
+                            <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
+                            <h5>{` ${this.props.verb} this review on `}</h5>
+                            <Card.Link href={`/paper_id=${this.props.target.content.id}`} className="text">
+                                {`${this.props.target.content.title}.`}
+                            </Card.Link>
+                        </Card.Header>
+                    );
+                } else {
+                    header = (
+                        <Card.Header id="headerSubscription">
+                            <Card.Link href={`/profile_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
+                            <h5>{` ${this.props.verb} this review.`}</h5>
+                        </Card.Header>
+                    );
+                }
+            } else if (this.props.paperSource) {
+                // legacy code: this line may not be needed
+                header = <Card.Header id="header">{`from ${this.props.paperSource}`}</Card.Header>;
+            }
         }
 
         return (
@@ -86,8 +108,9 @@ export default connect(mapStateToProps, mapDispatchToProps)(ReviewCard);
 ReviewCard.propTypes = {
     author: PropTypes.string,
     author_id: PropTypes.number,
-    source: PropTypes.string,
+    paperSource: PropTypes.string,
     id: PropTypes.number,
+    // eslint-disable-next-line react/no-unused-prop-types
     user: PropTypes.string,
     title: PropTypes.string,
     date: PropTypes.string,
@@ -99,12 +122,16 @@ ReviewCard.propTypes = {
     afterUnlikeCount: PropTypes.number,
     onLikeReview: PropTypes.func,
     onUnlikeReview: PropTypes.func,
+    subscription: PropTypes.bool,
+    actor: PropTypes.objectOf(PropTypes.any),
+    verb: PropTypes.string,
+    target: PropTypes.objectOf(PropTypes.any),
 };
 
 ReviewCard.defaultProps = {
     author: "",
     author_id: 0,
-    source: "",
+    paperSource: "",
     id: 0,
     user: "",
     title: "",
@@ -117,4 +144,8 @@ ReviewCard.defaultProps = {
     afterUnlikeCount: 0,
     onLikeReview: () => {},
     onUnlikeReview: () => {},
+    subscription: false,
+    actor: {},
+    verb: "",
+    target: {},
 };

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -40,15 +40,18 @@ class ReviewCard extends Component {
         let header = null;
         if (this.props.headerExists) {
             if (this.props.subscription) {
-                const headerLine = (
-                    <div><Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
-                        <h5>{` ${this.props.verb} this review on `}</h5>
-                    </div>
+                const actorLink = (
+                    <Card.Link
+                      className="actorLink"
+                      href={`/profile_id=${this.props.actor.id}`}
+                    >{this.props.actor.username}
+                    </Card.Link>
                 );
                 if (Object.keys(this.props.target).length !== 0) {
                     header = (
                         <Card.Header id="headerSubscriptionTarget" className="Header">
-                            {headerLine}
+                            {actorLink}
+                            <h5 className="verb">{` ${this.props.verb} this review on `}</h5>
                             <Card.Link href={`/paper_id=${this.props.target.content.id}`} className="text">
                                 {`${this.props.target.content.title}.`}
                             </Card.Link>
@@ -57,7 +60,8 @@ class ReviewCard extends Component {
                 } else {
                     header = (
                         <Card.Header id="headerSubscription" className="Header">
-                            {headerLine}
+                            {actorLink}
+                            <h5 className="verb">{` ${this.props.verb} this review.`}</h5>
                         </Card.Header>
                     );
                 }

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -65,9 +65,6 @@ class ReviewCard extends Component {
                         </Card.Header>
                     );
                 }
-            } else if (this.props.source) {
-                // legacy code: this line may not be needed
-                header = <Card.Header id="header" className="Header">{`from ${this.props.source}`}</Card.Header>;
             }
         }
 
@@ -115,7 +112,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(ReviewCard);
 ReviewCard.propTypes = {
     author: PropTypes.string,
     author_id: PropTypes.number,
-    source: PropTypes.string,
     id: PropTypes.number,
     // eslint-disable-next-line react/no-unused-prop-types
     user: PropTypes.string,

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -113,8 +113,6 @@ ReviewCard.propTypes = {
     author: PropTypes.string,
     author_id: PropTypes.number,
     id: PropTypes.number,
-    // eslint-disable-next-line react/no-unused-prop-types
-    user: PropTypes.string,
     title: PropTypes.string,
     date: PropTypes.string,
     likeCount: PropTypes.number,
@@ -135,7 +133,6 @@ ReviewCard.defaultProps = {
     author: "",
     author_id: 0,
     id: 0,
-    user: "",
     title: "",
     date: "",
     likeCount: 0,

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -40,11 +40,15 @@ class ReviewCard extends Component {
         let header = null;
         if (this.props.headerExists) {
             if (this.props.subscription) {
+                const headerLine = (
+                    <div><Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
+                        <h5>{` ${this.props.verb} this review on `}</h5>
+                    </div>
+                );
                 if (Object.keys(this.props.target).length !== 0) {
                     header = (
-                        <Card.Header id="headerSubscriptionTarget">
-                            <Card.Link href={`/profile_id=${this.props.actor.id}`} className="text">{this.props.actor.username}</Card.Link>
-                            <h5>{` ${this.props.verb} this review on `}</h5>
+                        <Card.Header id="headerSubscriptionTarget" className="Header">
+                            {headerLine}
                             <Card.Link href={`/paper_id=${this.props.target.content.id}`} className="text">
                                 {`${this.props.target.content.title}.`}
                             </Card.Link>
@@ -52,15 +56,14 @@ class ReviewCard extends Component {
                     );
                 } else {
                     header = (
-                        <Card.Header id="headerSubscription">
-                            <Card.Link href={`/profile_id=${this.props.id}`} className="text">{this.props.actor.username}</Card.Link>
-                            <h5>{` ${this.props.verb} this review.`}</h5>
+                        <Card.Header id="headerSubscription" className="Header">
+                            {headerLine}
                         </Card.Header>
                     );
                 }
             } else if (this.props.paperSource) {
                 // legacy code: this line may not be needed
-                header = <Card.Header id="header">{`from ${this.props.paperSource}`}</Card.Header>;
+                header = <Card.Header id="header" className="Header">{`from ${this.props.paperSource}`}</Card.Header>;
             }
         }
 

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -134,7 +134,6 @@ ReviewCard.propTypes = {
 ReviewCard.defaultProps = {
     author: "",
     author_id: 0,
-    source: "",
     id: 0,
     user: "",
     title: "",

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.js
@@ -61,9 +61,9 @@ class ReviewCard extends Component {
                         </Card.Header>
                     );
                 }
-            } else if (this.props.paperSource) {
+            } else if (this.props.source) {
                 // legacy code: this line may not be needed
-                header = <Card.Header id="header" className="Header">{`from ${this.props.paperSource}`}</Card.Header>;
+                header = <Card.Header id="header" className="Header">{`from ${this.props.source}`}</Card.Header>;
             }
         }
 
@@ -111,7 +111,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(ReviewCard);
 ReviewCard.propTypes = {
     author: PropTypes.string,
     author_id: PropTypes.number,
-    paperSource: PropTypes.string,
+    source: PropTypes.string,
     id: PropTypes.number,
     // eslint-disable-next-line react/no-unused-prop-types
     user: PropTypes.string,
@@ -134,7 +134,7 @@ ReviewCard.propTypes = {
 ReviewCard.defaultProps = {
     author: "",
     author_id: 0,
-    paperSource: "",
+    source: "",
     id: 0,
     user: "",
     title: "",

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
@@ -93,4 +93,29 @@ describe("<ReviewCard />", () => {
         const wrapper = component.find(".header");
         expect(wrapper.length).toBe(0);
     });
+
+    it("if headerExists && paperSource, then header should exist", () => {
+        reviewCard = makeReviewCard(stubInitialState, { headerExists: true, subscription: false, paperSource: "source" });
+        const component = mount(reviewCard);
+        const wrapper = component.find("#header").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("if headerExists && subscription, then subscription header should exist", () => {
+        reviewCard = makeReviewCard(stubInitialState, {
+            headerExists: true, subscription: true, target: {},
+        });
+        const component = mount(reviewCard);
+        const wrapper = component.find("#headerSubscription").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
+
+    it("if headerExists && subscription && target, then subscription header with target should exist", () => {
+        reviewCard = makeReviewCard(stubInitialState, {
+            headerExists: true, subscription: true, target: { content: { id: 1 } },
+        });
+        const component = mount(reviewCard);
+        const wrapper = component.find("#headerSubscriptionTarget").hostNodes();
+        expect(wrapper.length).toBe(1);
+    });
 });

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
@@ -94,13 +94,6 @@ describe("<ReviewCard />", () => {
         expect(wrapper.length).toBe(0);
     });
 
-    it("if headerExists && paperSource, then header should exist", () => {
-        reviewCard = makeReviewCard(stubInitialState, { headerExists: true, subscription: false, source: "source" });
-        const component = mount(reviewCard);
-        const wrapper = component.find("#header").hostNodes();
-        expect(wrapper.length).toBe(1);
-    });
-
     it("if headerExists && subscription, then subscription header should exist", () => {
         reviewCard = makeReviewCard(stubInitialState, {
             headerExists: true, subscription: true, target: {},

--- a/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
+++ b/frontend/src/components/Review/ReviewCard/ReviewCard.test.js
@@ -90,12 +90,12 @@ describe("<ReviewCard />", () => {
     it("if headerExists is false, then header should not exist", () => {
         reviewCard = makeReviewCard(stubInitialState, { headerExists: false });
         const component = mount(reviewCard);
-        const wrapper = component.find(".header");
+        const wrapper = component.find("#header");
         expect(wrapper.length).toBe(0);
     });
 
     it("if headerExists && paperSource, then header should exist", () => {
-        reviewCard = makeReviewCard(stubInitialState, { headerExists: true, subscription: false, paperSource: "source" });
+        reviewCard = makeReviewCard(stubInitialState, { headerExists: true, subscription: false, source: "source" });
         const component = mount(reviewCard);
         const wrapper = component.find("#header").hostNodes();
         expect(wrapper.length).toBe(1);

--- a/frontend/src/constants/constants.js
+++ b/frontend/src/constants/constants.js
@@ -36,6 +36,13 @@ export const notiStatus = {
     FAILURE: "FAILURE",
 };
 
+export const getSubscriptionsStatus = {
+    NONE: "NONE",
+    WAITING: "WAITING",
+    SUCCESS: "SUCCESS",
+    FAILURE: "FAILURE",
+};
+
 export const paperStatus = {
     NONE: "NONE",
     WAITING: "WAITING",

--- a/frontend/src/containers/Main/Main.css
+++ b/frontend/src/containers/Main/Main.css
@@ -1,3 +1,5 @@
+/* legacy codes: might be useful for further css works */
+
 .feeds {
     background: rgb(242,243,247);
     margin-left: 18%;

--- a/frontend/src/containers/Main/Main.js
+++ b/frontend/src/containers/Main/Main.js
@@ -1,100 +1,23 @@
+/* eslint-disable react/prefer-stateless-function */
 import React, { Component } from "react";
-import PropTypes from "prop-types";
+import SubscriptionFeed from "../Subscription/SubscriptionFeed";
 
-import {
-    CollectionCard, ReviewCard, PaperCard,
-} from "../../components";
-import "./Main.css";
+// import "./Main.css";
 
+// I want to give a choice for users to select what to display on their "Main".
+// The disabling of 'prefer-stateless-function' is the result of such plan.
+// If our team has not enough time or thinks it's unnecessary,
+// we may consider remove this component and set SubscriptionFeed as new "Main".
 class Main extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            feeds: [],
-        };
-
-        this.feedMaker = this.feedMaker.bind(this);
-    }
-
-    feedMaker = (feed) => {
-        if (feed.type === "Collection") {
-            return (
-                <CollectionCard
-                  source={feed.source}
-                  key={feed.id}
-                  id={feed.id}
-                  title={feed.title}
-                  user={feed.user}
-                  memberCount={feed.count.users}
-                  replyCount={feed.count.replies}
-                  paperCount={feed.count.papers}
-                  likeCount={feed.count.likes}
-                />
-            );
-        }
-        if (feed.type === "Review") {
-            return (
-                <ReviewCard
-                  source={feed.source}
-                  paperId={feed.paperId}
-                  author={feed.user.username}
-                  key={feed.id}
-                  id={feed.id}
-                  title={feed.title}
-                  user={feed.user}
-                  date={feed.date}
-                  likeCount={feed.count.likes}
-                  replyCount={feed.count.replies}
-                />
-            );
-        }
-        if (feed.type === "Paper") {
-            return (
-                <PaperCard
-                  key={feed.id}
-                  source={feed.source}
-                  id={feed.id}
-                  user={feed.user}
-                  title={feed.title}
-                  authors={feed.authors}
-                  date={feed.date}
-                  keywords={feed.keywords}
-                  likeCount={feed.count.likes}
-                  reviewCount={feed.count.reviews}
-                  addButtonExists
-                  history={this.props.history}
-                />
-            );
-        }
-        return null;
-    }
-
     render() {
-        const tmpMessage = "Welcome to PapersFeed. Subscription and Recommendation system will be ready soon!";
-        const feedsLeft = this.state.feeds.filter((x) => this.state.feeds.indexOf(x) % 2 === 0)
-            .map((feed) => this.feedMaker(feed));
-        const feedsRight = this.state.feeds.filter((x) => this.state.feeds.indexOf(x) % 2 === 1)
-            .map((feed) => this.feedMaker(feed));
-
         return (
             <div className="main">
                 <div className="feeds">
-                    <h2 id="tmp-message">{tmpMessage}</h2>
-                    <div className="board">
-                        <div className="left">{feedsLeft}</div>
-                        <div className="right">{feedsRight}</div>
-                    </div>
+                    <SubscriptionFeed />
                 </div>
             </div>
         );
     }
 }
+
 export default Main;
-
-Main.propTypes = {
-    history: PropTypes.objectOf(PropTypes.any),
-};
-
-Main.defaultProps = {
-    history: null,
-};

--- a/frontend/src/containers/Main/Main.test.js
+++ b/frontend/src/containers/Main/Main.test.js
@@ -1,8 +1,7 @@
 import React from "react";
-import { shallow, mount } from "enzyme";
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { ConnectedRouter } from "connected-react-router";
-import { Route, Switch } from "react-router-dom";
 import { getMockStore } from "../../test-utils/mocks";
 import Main from "./Main";
 import { collectionStatus, reviewStatus, signinStatus } from "../../constants/constants";
@@ -81,17 +80,7 @@ describe("<Main />", () => {
         main = (
             <Provider store={mockStore}>
                 <ConnectedRouter history={history}>
-                    <Switch>
-                        <Route
-                          path="/"
-                          exact
-                          render={() => (
-                              <div>
-                                  <Main location={{ pathname: "/paper_id=1" }} />
-                              </div>
-                          )}
-                        />
-                    </Switch>
+                    <Main />
                 </ConnectedRouter>
             </Provider>
         );
@@ -102,115 +91,8 @@ describe("<Main />", () => {
     });
 
     it("should render without errors", () => {
-        const component = shallow(<Main />);
+        const component = mount(main);
         const wrapper = component.find(".main");
         expect(wrapper.length).toBe(1);
-    });
-
-    it("should make feedsLeft and feedsRight well", () => {
-        const wrapper = mount(main);
-        const component = wrapper.find("Main");
-        component.instance().setState(
-            {
-                feeds: [{
-                    type: "Collection",
-                    source: "liked",
-                    id: 1,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        users: 1, likes: 0, papers: 14, replies: 15,
-                    },
-                }, {
-                    type: "Collection",
-                    source: "liked",
-                    id: 1,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        users: 1, likes: 0, papers: 14, replies: 15,
-                    },
-                }, {
-                    type: "Paper",
-                    source: "liked",
-                    id: 2,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        likes: 0, reviews: 15,
-                    },
-                }, {
-                    type: "Paper",
-                    source: "liked",
-                    id: 2,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        likes: 0, reviews: 15,
-                    },
-                }, {
-                    type: "Review",
-                    source: "liked",
-                    id: 3,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        likes: 0, replies: 15,
-                    },
-                }, {
-                    type: "Review",
-                    source: "liked",
-                    id: 3,
-                    title: "dfad",
-                    user: "Dfafdaf",
-                    count: {
-                        likes: 0, replies: 15,
-                    },
-                },
-                ],
-            },
-        );
-
-        wrapper.update();
-        const wrapperLeft = wrapper.find(".left");
-        const wrapperRight = wrapper.find(".right");
-        expect(wrapperLeft.children().length).toBe(3);
-        expect(wrapperRight.children().length).toBe(3);
-    });
-
-    it("should not make feedsLeft and feedsRight if wrong type", () => {
-        const wrapper = mount(main);
-        const component = wrapper.find("Main");
-
-        component.instance().setState(
-            {
-                feeds: [
-                    {
-                        type: "wrong type",
-                        source: "liked",
-                        id: 3,
-                        title: "dfad",
-                        user: "Dfafdaf",
-                        numPapers: 14,
-                        numReplies: 15,
-                    },
-                    {
-                        type: "wrong type",
-                        source: "liked",
-                        id: 4,
-                        title: "dfad",
-                        user: "Dfafdaf",
-                        numPapers: 14,
-                        numReplies: 15,
-                    },
-                ],
-            },
-        );
-
-        wrapper.update();
-        const wrapperLeft = wrapper.find(".left");
-        const wrapperRight = wrapper.find(".right");
-        expect(wrapperLeft.children().length).toBe(0);
-        expect(wrapperRight.children().length).toBe(0);
     });
 });

--- a/frontend/src/containers/Subscription/SubscriptionFeed.css
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.css
@@ -1,0 +1,44 @@
+.SubscriptionFeed {
+    min-height: 1000px;
+    background: rgb(242,243,247);
+    margin-left: 18%;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.SubscriptionFeed #SubscriptionText {
+    width: 96%;
+    height: 100%;
+    margin-top: 5%;
+    margin-bottom: 5%;
+    font-size: 200%;
+    font-weight: 700;
+}
+
+.SubscriptionFeed #subscriptionCards {
+    width: 90%;
+    height: 100%;
+    margin-left: 5%;
+    margin-right: 10%;
+    display: flex;
+    justify-content: flex-start;
+    flex-flow: row wrap;
+    align-items: flex-start;
+}
+
+.SubscriptionFeed #subscriptionCards #subscriptionCardsLeft {
+    width: 50%;
+    height: 100%;
+    display: flex;
+    justify-content: flex-start;
+    flex-direction: column;
+}
+
+.SubscriptionFeed #subscriptionCards #subscriptionCardsRight {
+    width: 50%;
+    height: 100%;
+    display: flex;
+    justify-content: flex-start;
+    flex-direction: column;
+}

--- a/frontend/src/containers/Subscription/SubscriptionFeed.js
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.js
@@ -107,7 +107,7 @@ class SubscriptionFeed extends Component {
 
         return (
             <div className="SubscriptionFeed">
-                <div id="SubscriptionText">My Subscription Feed</div>
+                {/* <div id="SubscriptionText">My Subscription Feed</div> */}
                 <div id="subscriptionCards">
                     <div id="subscriptionCardsLeft">{cardsLeft}</div>
                     <div id="subscriptionCardsRight">{cardsRight}</div>

--- a/frontend/src/containers/Subscription/SubscriptionFeed.js
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.js
@@ -1,0 +1,140 @@
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+
+import { PaperCard, CollectionCard, ReviewCard } from "../../components";
+import { authActions } from "../../store/actions";
+
+import "./SubscriptionFeed.css";
+
+class SubscriptionFeed extends Component {
+    componentDidMount() {
+        this.props.onGetSubscriptions();
+    }
+
+    // FIXME: if de-commentize those lines, somehow onGetSubscriptions is called recursively
+    // componentDidUpdate(prevProps) {
+    //     if (this.props.subscriptionItems !== prevProps.subscriptionItems) {
+    //         this.props.onGetSubscriptions();
+    //     }
+    // }
+
+    paperCardMaker = (key, paper, actor, verb, target) => (
+        <PaperCard
+          key={key}
+          id={paper.id}
+          title={paper.title}
+          authors={paper.authors}
+          keywords={paper.keywords}
+          likeCount={paper.count.likes}
+          reviewCount={paper.count.reviews}
+          isLiked={paper.liked}
+          addButtonExists
+          history={this.props.history}
+          headerExists
+          subscription
+          actor={actor}
+          verb={verb}
+          target={target}
+        />
+    )
+
+    collectionCardMaker = (key, collection, actor, verb, target) => (
+        <CollectionCard
+          key={key}
+          id={collection.id}
+          title={collection.title}
+          memberCount={collection.count.users}
+          paperCount={collection.count.papers}
+          replyCount={collection.count.replies}
+          likeCount={collection.count.likes}
+          isLiked={collection.liked}
+          headerExists
+          subscription
+          actor={actor}
+          verb={verb}
+          target={target}
+        />
+    )
+
+    reviewCardMaker = (key, review, actor, verb, target) => (
+        <ReviewCard
+          key={key}
+          id={review.id}
+          paperId={review.paper.id}
+          author={review.user.username}
+          author_id={review.user.id}
+          title={review.title}
+          isLiked={review.liked}
+          likeCount={review.count.likes}
+          replyCount={review.count.replies}
+          headerExists
+          subscription
+          actor={actor}
+          verb={verb}
+          target={target}
+        />
+    )
+
+    cardMaker = (item) => {
+        const itemType = item.action_object.type;
+        if (itemType === "paper") {
+            return this.paperCardMaker(
+                item.id, item.action_object.content, item.actor, item.verb, item.target,
+            );
+        }
+        if (itemType === "collection") {
+            return this.collectionCardMaker(
+                item.id, item.action_object.content, item.actor, item.verb, item.target,
+            );
+        }
+        if (itemType === "review") {
+            return this.reviewCardMaker(
+                item.id, item.action_object.content, item.actor, item.verb, item.target,
+            );
+        }
+        return null;
+    }
+
+    render() {
+        const cardsLeft = this.props.subscriptionItems
+            .filter((x) => this.props.subscriptionItems.indexOf(x) % 2 === 0)
+            .map((item) => this.cardMaker(item));
+
+        const cardsRight = this.props.subscriptionItems
+            .filter((x) => this.props.subscriptionItems.indexOf(x) % 2 === 1)
+            .map((item) => this.cardMaker(item));
+
+        return (
+            <div className="SubscriptionFeed">
+                <div id="SubscriptionText">My Subscription Feed</div>
+                <div id="subscriptionCards">
+                    <div id="subscriptionCardsLeft">{cardsLeft}</div>
+                    <div id="subscriptionCardsRight">{cardsRight}</div>
+                </div>
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    subscriptionItems: state.auth.subscriptions,
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    onGetSubscriptions: () => dispatch(authActions.getSubscriptions()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SubscriptionFeed);
+
+SubscriptionFeed.propTypes = {
+    history: PropTypes.objectOf(PropTypes.any),
+    subscriptionItems: PropTypes.arrayOf(PropTypes.any),
+    onGetSubscriptions: PropTypes.func,
+};
+
+SubscriptionFeed.defaultProps = {
+    history: null,
+    subscriptionItems: [],
+    onGetSubscriptions: () => {},
+};

--- a/frontend/src/containers/Subscription/SubscriptionFeed.test.js
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.test.js
@@ -1,0 +1,293 @@
+import React from "react";
+import { mount } from "enzyme";
+import { Provider } from "react-redux";
+import { ConnectedRouter } from "connected-react-router";
+
+import SubscriptionFeed from "./SubscriptionFeed";
+import {
+    signinStatus, signoutStatus, signupStatus, getMeStatus,
+    getSubscriptionsStatus, notiStatus, reviewStatus, collectionStatus,
+} from "../../constants/constants";
+import { getMockStore, mockPromise } from "../../test-utils/mocks";
+import { history } from "../../store/store";
+import { authActions } from "../../store/actions";
+
+const stubSubscriptions = [
+    {
+        action_object: {
+            content: {
+                count: {
+                    likes: 1,
+                    replies: 0,
+                },
+                creation_date: "2019-12-02T07:31:40.975",
+                id: 2,
+                liked: false,
+                modification_date: "2019-12-02T07:31:40.976",
+                paper: {
+                    DOI: "",
+                    ISSN: "",
+                    abstract: "We explain why semistability of a one-ended proper CAT(0) space can be↵determined by the geodesic rays. This is applied to boundaries of CAT(0)↵groups.",
+                    authors: [{
+                        address: "",
+                        email: "",
+                        first_name: "Ross",
+                        id: 53,
+                        last_name: "Geoghegan",
+                        rank: 1,
+                        researcher_id: "",
+                        type: "general",
+                    }],
+                    count: { reviews: 2, likes: 1 },
+                    download_url: "http://arxiv.org/pdf/1703.07003v1",
+                    eISSN: "",
+                    file_url: "http://arxiv.org/abs/1703.07003v1",
+                    id: 31,
+                    keywords: [],
+                    language: "english",
+                    liked: false,
+                    publication: {},
+                    title: "Semistability and CAT(0) Geometry",
+                },
+                text: "zxcbvzxcb",
+                title: "asfdas",
+                user: {
+                    id: 1,
+                    username: "asdf",
+                    email: "asdf@snu.ac.kr",
+                    description: "",
+                    count: {
+                        follower: 1,
+                        following: 1,
+                    },
+                },
+            },
+            type: "review",
+        },
+        actor: {
+            id: 2,
+            username: "girin",
+        },
+        creation_date: "2019-12-02T07:31:58.980",
+        id: 11,
+        target: {},
+        verb: "liked",
+    },
+    {
+        action_object: {
+            content: {
+                count: {
+                    users: 1,
+                    papers: 0,
+                    likes: 0,
+                    replies: 0,
+                },
+                creation_date: "2019-12-02T05:56:28.856",
+                id: 2,
+                liked: false,
+                modification_date: "2019-12-02T05:56:28.856",
+                text: "meowwww",
+                title: "girin",
+            },
+            type: "collection",
+        },
+        actor: { id: 2, username: "girin" },
+        creation_date: "2019-12-02T05:56:28.864",
+        id: 10,
+        target: {},
+        verb: "created",
+    },
+    {
+        action_object: {
+            type: "paper",
+            content: {
+                DOI: "10.2140/gt.2007.11.1255",
+                ISSN: "",
+                abstract: "This paper ... ",
+                authors: [
+                    {
+                        address: "",
+                        email: "",
+                        first_name: "Michael",
+                        id: 54,
+                        last_name: "Farber",
+                        rank: 1,
+                        researcher_id: "",
+                        type: "general",
+                    },
+                    {
+                        address: "",
+                        email: "",
+                        first_name: "Dirk",
+                        id: 55,
+                        last_name: "Schuetz",
+                        rank: 2,
+                        researcher_id: "",
+                        type: "general",
+                    },
+                ],
+                count: {
+                    reviews: 0,
+                    likes: 1,
+                },
+                download_url: "http://arxiv.org/pdf/math/0609005v1",
+                eISSN: "",
+                file_url: "http://arxiv.org/abs/math/0609005v1",
+                id: 32,
+                keywords: [],
+                language: "english",
+                liked: false,
+                publication: {},
+                title: "Cohomological estimates",
+            },
+        },
+        actor: {
+            id: 2,
+            username: "girin",
+        },
+        creation_date: "2019-12-02T03:41:13.561",
+        id: 9,
+        target: {},
+        verb: "liked",
+    },
+    {
+        action_object: {
+            type: "type that cannot exist",
+            content: {},
+        },
+        creation_date: "2019-12-02T03:41:13.561",
+        id: 9,
+        target: {},
+        verb: "liked",
+    },
+];
+
+describe("SubscriptionFeed test", () => {
+    let feed;
+
+    beforeEach(() => {
+        const stubInitialState = {
+            paper: {},
+            auth: {
+                signupStatus: signupStatus.NONE,
+                signinStatus: signinStatus.NONE,
+                signoutStatus: signoutStatus.NONE,
+                getMeStatus: getMeStatus.NONE,
+                getNotiStatus: notiStatus.NONE,
+                readNotiStatus: notiStatus.NONE,
+                getSubscriptionsStatus: getSubscriptionsStatus.SUCCESS,
+                notifications: [],
+                subscriptions: stubSubscriptions,
+                me: null,
+            },
+            collection: {
+                make: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: -1,
+                },
+                list: {
+                    status: collectionStatus.NONE,
+                    list: [],
+                    error: -1,
+                },
+                edit: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    error: -1,
+                },
+                delete: {
+                    status: collectionStatus.NONE,
+                    list: {},
+                    error: -1,
+                },
+                selected: {
+                    status: collectionStatus.NONE,
+                    collection: {},
+                    papers: [],
+                    members: [],
+                    replies: [],
+                    error: -1,
+                },
+                like: {
+                    status: collectionStatus.NONE,
+                    error: -1,
+                },
+                unlike: {
+                    status: collectionStatus.NONE,
+                    error: -1,
+                },
+            },
+            user: {},
+            review: {
+                make: {
+                    status: reviewStatus.NONE,
+                    review: {},
+                    error: null,
+                },
+                list: {
+                    status: reviewStatus.NONE,
+                    list: [],
+                    error: null,
+                },
+                edit: {
+                    status: reviewStatus.NONE,
+                    review: {},
+                    error: null,
+                },
+                delete: {
+                    status: reviewStatus.NONE,
+                    review: {},
+                    error: null,
+                },
+                selected: {
+                    status: reviewStatus.NONE,
+                    review: { id: 1 },
+                    error: null,
+                    replies: [],
+                },
+                like: {
+                    status: reviewStatus.NONE,
+                    count: 0,
+                    error: null,
+                },
+                unlike: {
+                    status: reviewStatus.NONE,
+                    count: 0,
+                    error: null,
+                },
+            },
+            reply: {},
+        };
+        const mockStore = getMockStore(stubInitialState);
+        feed = (
+            <Provider store={mockStore}>
+                <ConnectedRouter history={history}>
+                    <SubscriptionFeed />
+                </ConnectedRouter>
+            </Provider>
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should render well", () => {
+        const spyGetSubscription = jest.spyOn(authActions, "getSubscriptions")
+            .mockImplementation(() => () => mockPromise);
+
+        const component = mount(feed);
+        const wrapper = component.find(".SubscriptionFeed");
+        expect(wrapper.length).toBe(1);
+        expect(spyGetSubscription).toBeCalledTimes(1);
+
+        const wrapperLeft = component.find("#subscriptionCardsLeft");
+        const wrapperRight = component.find("#subscriptionCardsRight");
+        expect(component.find("PaperCard").length).toBe(1);
+        expect(component.find("CollectionCard").length).toBe(1);
+        expect(component.find("ReviewCard").length).toBe(1);
+        expect(wrapperLeft.children().length).toBe(2);
+        expect(wrapperRight.children().length).toBe(1);
+    });
+});

--- a/frontend/src/store/actions/actionTypes.js
+++ b/frontend/src/store/actions/actionTypes.js
@@ -114,6 +114,10 @@ export const authConstants = {
     // ReadNoti
     READ_NOTI_SUCCESS: "READ_NOTI_SUCCESS",
     READ_NOTI_FAILURE: "READ_NOTI_FAILURE",
+
+    // Subscription
+    GET_SUBSCRIPTION_SUCCESS: "GET_SUBSCRIPTION_SUCCESS",
+    GET_SUBSCRIPTION_FAILURE: "GET_SUBSCRIPTION_FAILURE",
 };
 
 export const paperConstants = {

--- a/frontend/src/store/actions/auth/auth.js
+++ b/frontend/src/store/actions/auth/auth.js
@@ -115,3 +115,17 @@ const readNotiFailure = (error) => ({
 export const readNoti = (notificationId) => (dispatch) => axios.put("/api/notification", notificationId)
     .then(() => dispatch(readNotiSuccess()))
     .catch((err) => dispatch(readNotiFailure(err)));
+
+const getSubscriptionsSuccess = (subscriptions) => ({
+    type: authConstants.GET_SUBSCRIPTION_SUCCESS,
+    target: subscriptions.subscriptions,
+});
+
+const getSubscriptionsFailure = (error) => ({
+    type: authConstants.GET_SUBSCRIPTION_FAILURE,
+    target: error,
+});
+
+export const getSubscriptions = () => (dispatch) => axios.get("/api/subscription")
+    .then((res) => dispatch(getSubscriptionsSuccess(res.data)))
+    .catch((err) => dispatch(getSubscriptionsFailure(err)));

--- a/frontend/src/store/actions/auth/auth.test.js
+++ b/frontend/src/store/actions/auth/auth.test.js
@@ -2,24 +2,10 @@ import axios from "axios";
 
 import { authActions } from "..";
 import {
-    signupStatus, signinStatus, signoutStatus, getMeStatus,
+    signupStatus, signinStatus, signoutStatus, getMeStatus, notiStatus, getSubscriptionsStatus,
 } from "../../../constants/constants";
 import { getMockStore } from "../../../test-utils/mocks";
 
-const stubInitialState = {
-    auth: {
-        signupStatus: signupStatus.NONE,
-        signinStatus: signinStatus.NONE,
-        signoutStatus: signoutStatus.NONE,
-        getMeStatus: getMeStatus.NONE,
-    },
-    collection: {},
-    paper: {},
-    user: {},
-    review: {},
-    reply: {},
-};
-const mockStore = getMockStore(stubInitialState);
 
 const stubSigningUpUser = {
     email: "my_email@papersfeed.com",
@@ -33,6 +19,31 @@ const stubSigningInUser = {
 };
 
 describe("authActions", () => {
+    let mockStore = null;
+
+    beforeEach(() => {
+        const stubInitialState = {
+            auth: {
+                signupStatus: signupStatus.NONE,
+                signinStatus: signinStatus.NONE,
+                signoutStatus: signoutStatus.NONE,
+                getMeStatus: getMeStatus.NONE,
+                getNotiStatus: notiStatus.NONE,
+                readNotiStatus: notiStatus.NONE,
+                getSubscriptionsStatus: getSubscriptionsStatus.NONE,
+                notifications: [],
+                subscriptions: [],
+                me: null,
+            },
+            collection: {},
+            paper: {},
+            user: {},
+            review: {},
+            reply: {},
+        };
+        mockStore = getMockStore(stubInitialState);
+    });
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -334,6 +345,42 @@ describe("authActions", () => {
         mockStore.dispatch(authActions.readNoti({ id: 1 }))
             .then(() => {
                 expect(spy).toHaveBeenCalledWith("/api/notification", { id: 1 });
+                done();
+            });
+    });
+
+    it("getSubscription should call axios.get", (done) => {
+        const spy = jest.spyOn(axios, "get")
+            .mockImplementation(() => new Promise((resolve) => {
+                const result = {
+                    status: 200,
+                    data: {},
+                };
+                resolve(result);
+            }));
+
+        mockStore.dispatch(authActions.getSubscriptions())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/subscription");
+                done();
+            });
+    });
+
+    it("getSubscription should handle error", (done) => {
+        const spy = jest.spyOn(axios, "get")
+            .mockImplementation(() => new Promise((_, reject) => {
+                const error = {
+                    response: {
+                        status: 403,
+                        data: {},
+                    },
+                };
+                reject(error);
+            }));
+
+        mockStore.dispatch(authActions.getSubscriptions())
+            .then(() => {
+                expect(spy).toHaveBeenCalledWith("/api/subscription");
                 done();
             });
     });

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -8,6 +8,7 @@ import {
     getMe,
     getNoti,
     readNoti,
+    getSubscriptions,
 } from "./auth/auth";
 
 import {
@@ -114,6 +115,7 @@ export const authActions = {
     getMe,
     getNoti,
     readNoti,
+    getSubscriptions,
 };
 export const paperActions = {
     getPaper,

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -1,6 +1,6 @@
 import { authConstants } from "../../actions/actionTypes";
 import {
-    signupStatus, signinStatus, signoutStatus, getMeStatus, notiStatus,
+    signupStatus, signinStatus, signoutStatus, getMeStatus, notiStatus, getSubscriptionsStatus,
 } from "../../../constants/constants";
 
 const initialState = {
@@ -10,7 +10,9 @@ const initialState = {
     getMeStatus: getMeStatus.NONE,
     getNotiStatus: notiStatus.NONE,
     readNotiStatus: notiStatus.NONE,
+    getSubscriptionsStatus: getSubscriptionsStatus.NONE,
     notifications: [],
+    subscriptions: [],
     me: null,
 };
 
@@ -49,6 +51,15 @@ const reducer = (state = initialState, action) => {
         return { ...state, readNotiStatus: notiStatus.SUCCESS };
     case authConstants.READ_NOTI_FAILURE:
         return { ...state, readNotiStatus: notiStatus.FAILURE };
+
+    case authConstants.GET_SUBSCRIPTION_SUCCESS:
+        return {
+            ...state,
+            getSubscriptionsStatus: getSubscriptionsStatus.SUCCESS,
+            subscriptions: action.target,
+        };
+    case authConstants.GET_SUBSCRIPTION_FAILURE:
+        return { ...state, getSubscriptionsStatus: getSubscriptionsStatus.FAILURE };
 
     default:
         return { ...state };

--- a/frontend/src/store/reducers/auth/auth.test.js
+++ b/frontend/src/store/reducers/auth/auth.test.js
@@ -1,8 +1,21 @@
 import reducer from "./auth";
 import { authConstants } from "../../actions/actionTypes";
 import {
-    signupStatus, signinStatus, signoutStatus, getMeStatus, notiStatus,
+    signupStatus, signinStatus, signoutStatus, getMeStatus, notiStatus, getSubscriptionsStatus,
 } from "../../../constants/constants";
+
+const stubInitialState = {
+    signupStatus: signupStatus.NONE,
+    signinStatus: signinStatus.NONE,
+    signoutStatus: signoutStatus.NONE,
+    getMeStatus: getMeStatus.NONE,
+    getNotiStatus: notiStatus.NONE,
+    readNotiStatus: notiStatus.NONE,
+    getSubscriptionsStatus: getSubscriptionsStatus.NONE,
+    notifications: [],
+    subscriptions: [],
+    me: null,
+};
 
 const stubSigningUpUser = {
     email: "my_email@papersfeed.com",
@@ -22,200 +35,102 @@ const stubError = {
     },
 };
 
+const stubSubscription = ["stubSubscription"];
+
 describe("Auth reducer", () => {
     it("should return default state", () => {
-        const newState = reducer(undefined, {});
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
+        const newState = reducer(stubInitialState, {
+            type: "NO SUCH TYPE",
+            target: "HAHAHAHAHAHAHAHAHAHAHAHA",
         });
+        expect(newState).toEqual(stubInitialState);
     });
 
     it("should handle signup success", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNUP_SUCCESS,
             target: stubSigningUpUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.SUCCESS,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signupStatus).toBe(signupStatus.SUCCESS);
     });
 
     it("should handle signup duplicate email", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNUP_FAILURE_DUPLICATE_EMAIL,
             target: stubSigningUpUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.DUPLICATE_EMAIL,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signupStatus).toBe(signupStatus.DUPLICATE_EMAIL);
     });
 
     it("should handle signup duplicate username", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNUP_FAILURE_DUPLICATE_USERNAME,
             target: stubSigningUpUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.DUPLICATE_USERNAME,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signupStatus).toBe(signupStatus.DUPLICATE_USERNAME);
     });
 
-
     it("should handle signin success", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNIN_SUCCESS,
             target: stubSigningInUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.SUCCESS,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: {
-                email: "my_email@papersfeed.com",
-                password: "swpp",
-            },
-        });
+        expect(newState.signinStatus).toBe(signinStatus.SUCCESS);
+        expect(newState.me).toBe(stubSigningInUser);
     });
 
     it("should handle signin user not exist", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNIN_FAILURE_USER_NOT_EXIST,
             target: stubSigningInUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.USER_NOT_EXIST,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signinStatus).toBe(signinStatus.USER_NOT_EXIST);
     });
 
     it("should handle signin wrong password", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNIN_FAILURE_WRONG_PW,
             target: stubSigningInUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.WRONG_PW,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signinStatus).toBe(signinStatus.WRONG_PW);
     });
 
-
     it("should process signout", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNOUT_SUCCESS,
             target: null,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.SUCCESS,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signoutStatus).toBe(signoutStatus.SUCCESS);
     });
 
     it("should handle signout failure", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.SIGNOUT_FAILURE,
             target: null,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.FAILURE,
-            getMeStatus: getMeStatus.NONE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.signoutStatus).toBe(signoutStatus.FAILURE);
     });
 
-
     it("should process getMe", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.GETME_SUCCESS,
             target: stubSigningInUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.SUCCESS,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: stubSigningInUser,
-        });
+        expect(newState.getMeStatus).toBe(getMeStatus.SUCCESS);
+        expect(newState.me).toBe(stubSigningInUser);
     });
 
     it("should handle getMe failure", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.GETME_FAILURE,
             target: stubSigningInUser,
         });
-        expect(newState).toEqual({
-            signupStatus: signupStatus.NONE,
-            signinStatus: signinStatus.NONE,
-            signoutStatus: signoutStatus.NONE,
-            getMeStatus: getMeStatus.FAILURE,
-            getNotiStatus: notiStatus.NONE,
-            readNotiStatus: notiStatus.NONE,
-            notifications: [],
-            me: null,
-        });
+        expect(newState.getMeStatus).toBe(getMeStatus.FAILURE);
     });
 
 
     it("should process getNotifications", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.GET_NOTI_SUCCESS,
             target: [{
                 id: 1, actor: { id: 1 }, action_object: { id: 1 }, verb: "liked",
@@ -228,7 +143,7 @@ describe("Auth reducer", () => {
     });
 
     it("should handle getMe failure", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.GET_NOTI_FAILURE,
             target: stubError,
         });
@@ -237,7 +152,7 @@ describe("Auth reducer", () => {
 
 
     it("should process readNotification", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.READ_NOTI_SUCCESS,
             target: null,
         });
@@ -245,10 +160,27 @@ describe("Auth reducer", () => {
     });
 
     it("should handle readNotification failure", () => {
-        const newState = reducer(undefined, {
+        const newState = reducer(stubInitialState, {
             type: authConstants.READ_NOTI_FAILURE,
             target: stubError,
         });
         expect(newState.readNotiStatus).toEqual(notiStatus.FAILURE);
+    });
+
+    it("should handle getSubscription", () => {
+        const newState = reducer(stubInitialState, {
+            type: authConstants.GET_SUBSCRIPTION_SUCCESS,
+            target: stubSubscription,
+        });
+        expect(newState.getSubscriptionsStatus).toBe(getSubscriptionsStatus.SUCCESS);
+        expect(newState.subscriptions).toBe(stubSubscription);
+    });
+
+    it("should handle getSubscription failure", () => {
+        const newState = reducer(stubInitialState, {
+            type: authConstants.GET_SUBSCRIPTION_FAILURE,
+            target: stubError,
+        });
+        expect(newState.getSubscriptionsStatus).toBe(getSubscriptionsStatus.FAILURE);
     });
 });


### PR DESCRIPTION
Related Issue: #124

# Major changes
![image](https://user-images.githubusercontent.com/54832818/69951421-91ff4900-1538-11ea-99ac-4a701317b988.png)



- Subscription Feed on Main Page is now implemented.
- Change on headers of card components. Now they shows why the card is shown to the subscription feed. The header will not be shown when cards are rendered in other pages.
- Redux things for subscription feed are also implemented, of course.


# Minor changes
- Minor change on .../Subscription/utils.py, as it was sending action_object as an array which has one element, which I didn't intend to. The element is what I really wanted to be as action_object.
- Minor change on .../likes/utils.py, which I omitted to change at #132.
- Some changes on existing frontend test.



### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, mentions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
