### PR TITLE
Fixing bug on AddPaperModal & Adapting AddPaperModal and CollectionList to Pagination

### DIFF
--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -1,6 +1,7 @@
 """utils.py"""
 # -*- coding: utf-8 -*-
 
+from django.db import transaction
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q, Exists, OuterRef, Count, Case, When
 
@@ -300,6 +301,7 @@ def select_collection_like(args):
     return collections, page_number, is_finished
 
 
+@transaction.atomic
 def update_paper_collection(args):
     """Update Paper Collection"""
 
@@ -357,7 +359,7 @@ def get_collections(filter_query, request_user, count, params=None, page_number=
 
 def __get_collections_contains_paper(paper_id, request_user):
     """Get Collections Containing paper"""
-    collections = CollectionUser.objects.filter(
+    collection_users = CollectionUser.objects.filter(
         user_id=request_user.id  # User's Collections
     ).annotate(
         exists=Exists(
@@ -370,7 +372,7 @@ def __get_collections_contains_paper(paper_id, request_user):
         exists=True
     )
 
-    return [collection.id for collection in collections]
+    return [collection_user.collection_id for collection_user in collection_users]
 
 
 def __remove_paper_from_collections(paper_id, collection_ids, request_user):

--- a/frontend/src/components/Modal/AddPaperModal/AddPaperModal.css
+++ b/frontend/src/components/Modal/AddPaperModal/AddPaperModal.css
@@ -14,22 +14,9 @@
     align-items: center;
 }
 
-/*.modal-header #header-buttons {
+.modal-header #header-buttons {
     display: flex;
     justify-content: space-around;
-    padding-left: 5px;
-    background: red;
-}*/
-
-#update-message {
-    font-size: 100%;
-    color: #DC143C;
-    margin-top: 8%;
-}
-
-.cancel-button {
-    margin-left: 5%;
-    padding-left: 10px;
 }
 
 #add-paper-to-my-collections {

--- a/frontend/src/components/Modal/AddPaperModal/AddPaperModal.js
+++ b/frontend/src/components/Modal/AddPaperModal/AddPaperModal.js
@@ -32,8 +32,6 @@ class AddPaperModal extends Component {
         this.clickUpdateButtonHandler = this.clickUpdateButtonHandler.bind(this);
     }
 
-    equalTwoChecked = (before, curr) => before.sort().toString() === curr.sort().toString()
-
     getCollectionsTrigger(pageNum) {
         this.props.onGetCollectionsWithContains({
             id: this.props.me.id, paper: this.props.id, page_number: pageNum + 1,
@@ -54,6 +52,8 @@ class AddPaperModal extends Component {
             })
             .catch(() => {});
     }
+
+    equalTwoChecked = (before, curr) => before.sort().toString() === curr.sort().toString()
 
     openAddPaperHandler() {
         this.getCollectionsTrigger(0);

--- a/frontend/src/components/Modal/AddPaperModal/AddPaperModal.test.js
+++ b/frontend/src/components/Modal/AddPaperModal/AddPaperModal.test.js
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { collectionStatus, signinStatus } from "../../../constants/constants";
 import AddPaperModal from "./AddPaperModal";
 import {
-    getMockStore, mockComponent, mockPromise, flushPromises,
+    getMockStore, mockPromise, flushPromises,
 } from "../../../test-utils/mocks";
 import { collectionActions } from "../../../store/actions";
 
@@ -15,7 +15,6 @@ const makeAddPaperModal = (initialState) => (
     </Provider>
 );
 
-jest.mock("../GoMyCollectionsModal/GoMyCollectionsModal", () => jest.fn(() => (mockComponent("GoMyCollectionsModal")())));
 jest.mock("../../Collection/CollectionEntry/CollectionEntry", () => jest.fn((props) => (
     <input
       className="check-entry"
@@ -104,29 +103,13 @@ describe("<AddPaperModal />", () => {
         const openButton = component.find(".addpaper-open-button").hostNodes();
         expect(openButton.length).toBe(1);
 
-        let wrapper = component.find(".add-button").hostNodes();
+        let wrapper = component.find(".update-button").hostNodes();
         expect(wrapper.length).toBe(0);
 
         openButton.simulate("click");
         expect(spyGetCollections).toHaveBeenCalledTimes(1);
 
-        wrapper = component.find(".add-button").hostNodes();
-        expect(wrapper.length).toBe(1);
-    });
-
-    it("should open if adding paper or creating collection succeeds", () => {
-        const component = mount(addPaperModal);
-        const addPaperModalInstance = component.find(AddPaperModal.WrappedComponent).instance();
-
-        const openButton = component.find(".addpaper-open-button").hostNodes();
-        openButton.simulate("click");
-
-        let wrapper = component.find(".GoMyCollectionsModal");
-        expect(wrapper.length).toBe(0);
-
-        addPaperModalInstance.setState({ addPaperCollectionStatus: collectionStatus.SUCCESS });
-        component.update();
-        wrapper = component.find(".GoMyCollectionsModal");
+        wrapper = component.find(".update-button").hostNodes();
         expect(wrapper.length).toBe(1);
     });
 
@@ -247,16 +230,27 @@ describe("<AddPaperModal />", () => {
         const openButton = component.find(".addpaper-open-button").hostNodes();
         openButton.simulate("click");
 
-        const addButton = component.find(".add-button").hostNodes();
+        const addButton = component.find(".update-button").hostNodes();
         addButton.simulate("click");
 
         expect(spyAddPaper).toHaveBeenCalledTimes(1);
         await flushPromises();
-        expect(addPaperModalInstance.state.addPaperCollectionStatus).toBe(collectionStatus.SUCCESS);
+        expect(addPaperModalInstance.props.addPaperCollectionStatus).toBe(collectionStatus.SUCCESS);
     });
 
     it("should not handle add paper to collection", async () => {
-        const component = mount(addPaperModal);
+        stubInitialState = {
+            ...stubInitialState,
+            collection: {
+                ...stubInitialState.collection,
+                edit: {
+                    status: collectionStatus.FAILURE,
+                    collection: {},
+                    error: null,
+                },
+            },
+        };
+        const component = mount(makeAddPaperModal(stubInitialState));
         const addPaperModalInstance = component.find("AddPaperModal").instance();
 
         addPaperModalInstance.setState({
@@ -268,12 +262,12 @@ describe("<AddPaperModal />", () => {
         const openButton = component.find(".addpaper-open-button").hostNodes();
         openButton.simulate("click");
 
-        const addButton = component.find(".add-button").hostNodes();
+        const addButton = component.find(".update-button").hostNodes();
         addButton.simulate("click");
 
         expect(spyAddPaper).toHaveBeenCalledTimes(1);
         await flushPromises();
-        expect(addPaperModalInstance.state.addPaperCollectionStatus).toBe(collectionStatus.FAILURE);
+        expect(addPaperModalInstance.props.addPaperCollectionStatus).toBe(collectionStatus.FAILURE);
     });
 
     it("should handle make a new colelction and add paper to collection", async () => {
@@ -323,13 +317,13 @@ describe("<AddPaperModal />", () => {
         const openButton = component.find(".addpaper-open-button").hostNodes();
         openButton.simulate("click");
 
-        const addButton = component.find(".add-button").hostNodes();
+        const addButton = component.find(".update-button").hostNodes();
         addButton.simulate("click");
 
         expect(spyMakeNewCollection).toHaveBeenCalledTimes(1);
         await flushPromises();
         component.update();
-        expect(addPaperModalInstance.state.makeNewCollectionStatus).toBe(collectionStatus.SUCCESS);
+        expect(addPaperModalInstance.props.makeNewCollectionStatus).toBe(collectionStatus.SUCCESS);
 
         expect(spyAddPaper).toHaveBeenCalledTimes(1);
         await flushPromises();
@@ -350,8 +344,9 @@ describe("<AddPaperModal />", () => {
         const openButton = component.find(".addpaper-open-button").hostNodes();
         openButton.simulate("click");
 
-        const addButton = component.find(".add-button").hostNodes();
+        const addButton = component.find(".update-button").hostNodes();
         addButton.simulate("click");
-        expect(addPaperModalInstance.state.updateMessage).toEqual("Nothing changed!");
+        expect(spyAddPaper).toHaveBeenCalledTimes(0);
+        expect(spyMakeNewCollection).toHaveBeenCalledTimes(0);
     });
 });

--- a/frontend/src/components/Modal/GoMyCollectionsModal/GoMyCollectionsModal.js
+++ b/frontend/src/components/Modal/GoMyCollectionsModal/GoMyCollectionsModal.js
@@ -1,16 +1,25 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Modal, Button } from "react-bootstrap";
+
 import "./GoMyCollectionsModal.css";
 
 class GoMyCollectionsModal extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            isModalOpen: this.props.openTrigger,
+            isModalOpen: false,
         };
-        this.clickCancelButtonHandler = this.clickCancelButtonHandler.bind(this);
+
+        this.clickUpdateButtonHandler = this.clickUpdateButtonHandler.bind(this);
+        this.clickCancelHandler = this.clickCancelHandler.bind(this);
         this.clickGotoButtonHandler = this.clickGotoButtonHandler.bind(this);
+    }
+
+    clickUpdateButtonHandler = () => {
+        this.props.whatActionWillBeDone();
+        // NOTE: this modal will be open even though updating fails
+        this.setState({ isModalOpen: true });
     }
 
     clickGotoButtonHandler() {
@@ -18,15 +27,23 @@ class GoMyCollectionsModal extends Component {
         this.props.history.push("/collections");
     }
 
-    clickCancelButtonHandler() {
+    clickCancelHandler() {
         this.setState({ isModalOpen: false });
     }
 
     render() {
         return (
             <div className="gotomycollectionsmodal">
+                <Button
+                  className="update-button"
+                  onClick={this.clickUpdateButtonHandler}
+                  disabled={this.props.disableCondition}
+                >
+                    Update
+                </Button>
                 <Modal
                   show={this.state.isModalOpen}
+                  onHide={this.clickCancelHandler}
                   className="modal"
                   centered
                 >
@@ -41,7 +58,7 @@ class GoMyCollectionsModal extends Component {
                               onClick={this.clickGotoButtonHandler}
                             >My Collection
                             </Button>
-                            <Button className="cancel-button" onClick={this.clickCancelButtonHandler}>Cancel</Button>
+                            <Button className="cancel-button" onClick={this.clickCancelHandler}>Cancel</Button>
                         </div>
                     </Modal.Body>
                     <Modal.Footer>
@@ -57,10 +74,12 @@ export default GoMyCollectionsModal;
 
 GoMyCollectionsModal.propTypes = {
     history: PropTypes.objectOf(PropTypes.any),
-    openTrigger: PropTypes.bool,
+    whatActionWillBeDone: PropTypes.func,
+    disableCondition: PropTypes.bool,
 };
 
 GoMyCollectionsModal.defaultProps = {
     history: null,
-    openTrigger: false,
+    whatActionWillBeDone: () => {},
+    disableCondition: true,
 };

--- a/frontend/src/components/Modal/GoMyCollectionsModal/GoMyCollectionsModal.test.js
+++ b/frontend/src/components/Modal/GoMyCollectionsModal/GoMyCollectionsModal.test.js
@@ -17,15 +17,22 @@ describe("<GoMyCollectionsModal />", () => {
     });
 
     it("should open addpapermodal when openTrigger", () => {
-        const component = mount(<GoMyCollectionsModal openTrigger />);
-        const wrapper = component.find(".go-button").hostNodes();
+        const component = mount(<GoMyCollectionsModal disableCondition={false} />);
+        const wrapper = component.find(".update-button").hostNodes();
 
         expect(wrapper.length).toBe(1);
+        wrapper.simulate("click");
+
+        const instance = component.find(GoMyCollectionsModal).instance();
+        expect(instance.state.isModalOpen).toBe(true);
     });
 
     it("should be closed if cancelButton is clicked", () => {
-        const component = mount(<GoMyCollectionsModal openTrigger />);
-        const wrapper = component.find(".go-button").hostNodes();
+        const component = mount(<GoMyCollectionsModal disableCondition={false} />);
+        let wrapper = component.find(".update-button").hostNodes();
+        wrapper.simulate("click");
+
+        wrapper = component.find(".go-button").hostNodes();
         const gotoModalInstance = component.find(GoMyCollectionsModal).instance();
 
         expect(wrapper.length).toBe(1);
@@ -38,7 +45,13 @@ describe("<GoMyCollectionsModal />", () => {
     });
 
     it("should redirect to Collection List Page if go-button is clicked", () => {
-        const component = mount(<GoMyCollectionsModal openTrigger history={mockHistory} />);
+        const component = mount(<GoMyCollectionsModal
+          disableCondition={false}
+          history={mockHistory}
+        />);
+        const wrapper = component.find(".update-button").hostNodes();
+        wrapper.simulate("click");
+
         const goButton = component.find(".go-button").hostNodes();
         const gotoModalInstance = component.find(GoMyCollectionsModal).instance();
 

--- a/frontend/src/components/Modal/IntroModal/IntroModal.js
+++ b/frontend/src/components/Modal/IntroModal/IntroModal.js
@@ -22,7 +22,7 @@ class IntroModal extends Component {
         this.openSigninHandler = this.openSigninHandler.bind(this);
         this.clickSignupButtonHandler = this.clickSignupButtonHandler.bind(this);
         this.clickSigninButtonHandler = this.clickSigninButtonHandler.bind(this);
-        this.clickCancelButtonHandler = this.clickCancelButtonHandler.bind(this);
+        this.clickCancelHandler = this.clickCancelHandler.bind(this);
     }
 
     openSignupHandler() {
@@ -93,7 +93,7 @@ class IntroModal extends Component {
             });
     }
 
-    clickCancelButtonHandler() {
+    clickCancelHandler() {
         this.setState({
             signupStatus: signupStatus.NONE,
             signinStatus: signinStatus.NONE,
@@ -137,7 +137,7 @@ class IntroModal extends Component {
             modalHeader = (
                 <Modal.Header>
                     <h2 id="create-account">Create account</h2>
-                    <Button className="cancel-button" onClick={this.clickCancelButtonHandler}>Cancel</Button>
+                    <Button className="cancel-button" onClick={this.clickCancelHandler}>Cancel</Button>
                 </Modal.Header>
             );
             usernameInput = (
@@ -170,7 +170,7 @@ class IntroModal extends Component {
             modalHeader = (
                 <Modal.Header>
                     <h2 id="welcome-back">Welcome back</h2>
-                    <Button className="cancel-button" onClick={this.clickCancelButtonHandler}>Cancel</Button>
+                    <Button className="cancel-button" onClick={this.clickCancelHandler}>Cancel</Button>
                 </Modal.Header>
             );
             modalFooter = (
@@ -193,6 +193,7 @@ class IntroModal extends Component {
                 </div>
                 <Modal
                   show={this.state.isSignupOpen || this.state.isSigninOpen}
+                  onHide={this.clickCancelHandler}
                   className="signup-modal"
                   centered
                 >

--- a/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
+++ b/frontend/src/components/Modal/ManageCollectionMemberModal/ManageCollectionMemberModal.js
@@ -22,6 +22,7 @@ class ManageCollectionMemberModal extends Component {
         };
 
         this.getMembersTrigger = this.getMembersTrigger.bind(this);
+        this.refreshMembers = this.refreshMembers.bind(this);
         this.clickOpenHandler = this.clickOpenHandler.bind(this);
         this.clickCloseHandler = this.clickCloseHandler.bind(this);
         this.clickKickOffCancelHandler = this.clickKickOffCancelHandler.bind(this);

--- a/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
+++ b/frontend/src/components/Modal/TrasferOwnershipModal/TransferOwnershipModal.js
@@ -19,7 +19,7 @@ class TransferOwnershipModal extends Component {
             memberFinished: true,
         };
 
-
+        this.getMembersTrigger = this.getMembersTrigger.bind(this);
         this.clickOpenHandler = this.clickOpenHandler.bind(this);
         this.clickCancelHandler = this.clickCancelHandler.bind(this);
         this.checkHandler = this.checkHandler.bind(this);

--- a/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
+++ b/frontend/src/containers/Collection/CollectionDetail/CollectionDetail.js
@@ -160,7 +160,7 @@ class CollectionDetail extends Component {
                   members={this.props.members}
                   whatActionWillFollow={
                       () => {
-                          this.props.onGetMembers()
+                          this.props.onGetMembers(this.props.selectedCollection.id)
                               .then(() => {
                                   this.setState({
                                       userCount: this.props.memberCount,

--- a/frontend/src/containers/Collection/CollectionList/CollectionList.js
+++ b/frontend/src/containers/Collection/CollectionList/CollectionList.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 
 import { CreateNewCollectionModal, CollectionCard } from "../../../components";
 import { collectionActions } from "../../../store/actions";
@@ -8,18 +9,38 @@ import { collectionActions } from "../../../store/actions";
 import "./CollectionList.css";
 
 class CollectionList extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            collections: [],
+        };
+
+        this.getCollectionsTrigger = this.getCollectionsTrigger.bind(this);
+        this.cardsMaker = this.cardsMaker.bind(this);
+    }
+
     componentDidMount() {
         if (this.props.me) {
-            this.props.onGetCollections({ id: this.props.me.id })
-                .catch(() => {});
+            this.getCollectionsTrigger(0);
         }
     }
 
     componentDidUpdate(prevProps) {
         if (this.props.me !== prevProps.me) {
-            this.props.onGetCollections({ id: this.props.me.id })
-                .catch(() => {});
+            this.getCollectionsTrigger(0);
         }
+    }
+
+    getCollectionsTrigger(pageNum) {
+        this.props.onGetCollections({
+            id: this.props.me.id,
+            page_number: pageNum + 1,
+        })
+            .then(() => {
+                const { collections } = this.state;
+                this.setState({ collections: collections.concat(this.props.storedCollections) });
+            })
+            .catch(() => {});
     }
 
     cardsMaker = (collection) => (
@@ -39,12 +60,12 @@ class CollectionList extends Component {
     )
 
     render() {
-        const collectionCardsLeft = this.props.storedCollections
-            .filter((x) => this.props.storedCollections.indexOf(x) % 2 === 0)
+        const collectionCardsLeft = this.state.collections
+            .filter((x) => this.state.collections.indexOf(x) % 2 === 0)
             .map((collection) => this.cardsMaker(collection));
 
-        const collectionCardsRight = this.props.storedCollections
-            .filter((x) => this.props.storedCollections.indexOf(x) % 2 === 1)
+        const collectionCardsRight = this.state.collections
+            .filter((x) => this.state.collections.indexOf(x) % 2 === 1)
             .map((collection) => this.cardsMaker(collection));
 
         return (
@@ -58,6 +79,19 @@ class CollectionList extends Component {
                         <div id="collectionCardsLeft">{collectionCardsLeft}</div>
                         <div id="collectionCardsRight">{collectionCardsRight}</div>
                     </div>
+                    { this.props.collectionFinished ? null
+                        : (
+                            <Button
+                              className="collection-more-button"
+                              onClick={() => this.getCollectionsTrigger(
+                                  this.props.collectionPageNum,
+                              )}
+                              size="lg"
+                              block
+                            >
+                            View More
+                            </Button>
+                        )}
                 </div>
             </div>
         );
@@ -67,6 +101,8 @@ class CollectionList extends Component {
 const mapStateToProps = (state) => ({
     me: state.auth.me,
     storedCollections: state.collection.list.list,
+    collectionPageNum: state.collection.list.pageNum,
+    collectionFinished: state.collection.list.finished,
     makeNewCollectionStatus: state.collection.make.status,
     getCollectionsStatus: state.collection.list.status,
 });
@@ -81,10 +117,14 @@ CollectionList.propTypes = {
     me: PropTypes.objectOf(PropTypes.any),
     onGetCollections: PropTypes.func,
     storedCollections: PropTypes.arrayOf(PropTypes.any),
+    collectionPageNum: PropTypes.number,
+    collectionFinished: PropTypes.bool,
 };
 
 CollectionList.defaultProps = {
     me: null,
     storedCollections: [],
     onGetCollections: () => {},
+    collectionPageNum: 0,
+    collectionFinished: true,
 };

--- a/frontend/src/containers/Collection/CollectionList/CollectionList.test.js
+++ b/frontend/src/containers/Collection/CollectionList/CollectionList.test.js
@@ -6,7 +6,7 @@ import { ConnectedRouter } from "connected-react-router";
 import CollectionList from "./CollectionList";
 import { collectionStatus } from "../../../constants/constants";
 import { collectionActions } from "../../../store/actions";
-import { getMockStore, mockPromise } from "../../../test-utils/mocks";
+import { getMockStore, mockPromise, flushPromises } from "../../../test-utils/mocks";
 import { history } from "../../../store/store";
 
 const makeCollectionList = (initialState) => (
@@ -146,5 +146,32 @@ describe("CollectionList test", () => {
         expect(wrapperRight.length).toBe(1);
 
         expect(spyGetCollections).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show more if collection-more-button clicked", async () => {
+        stubInitialState = {
+            ...stubInitialState,
+            collection: {
+                ...stubInitialState.collection,
+                list: {
+                    status: collectionStatus.SUCCESS,
+                    list: [],
+                    pageNum: 1,
+                    finished: false,
+                },
+            },
+        };
+        const component = mount(makeCollectionList(stubInitialState));
+
+        expect(spyGetCollections).toBeCalledTimes(1);
+        await flushPromises();
+        component.update();
+
+        const wrapper = component.find(".collection-more-button").hostNodes();
+        expect(wrapper.length).toBe(1);
+        wrapper.simulate("click");
+
+        expect(spyGetCollections).toBeCalledTimes(2);
+        await flushPromises();
     });
 });

--- a/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
+++ b/frontend/src/containers/Collection/CollectionManage/CollectionManage.js
@@ -17,6 +17,8 @@ class CollectionManage extends Component {
             collectionName: "",
             collectionDescription: "",
         };
+
+        this.updateCollectionHandler = this.updateCollectionHandler.bind(this);
     }
 
     componentDidMount() {

--- a/frontend/src/store/actions/collection/collection.js
+++ b/frontend/src/store/actions/collection/collection.js
@@ -25,9 +25,13 @@ export const makeNewCollection = (collection) => (dispatch) => axios.post("/api/
 
 
 // getCollectionsByUserId
-const getCollectionsByUserIdSuccess = (collections) => ({
+const getCollectionsByUserIdSuccess = (data) => ({
     type: collectionConstants.GET_COLLECTIONS,
-    target: collections.collections,
+    target: {
+        collections: data.collections,
+        pageNum: data.page_number,
+        finished: data.is_finished,
+    },
 });
 
 const getCollectionsByUserIdFailure = (error) => ({

--- a/frontend/src/store/reducers/collection/collection.js
+++ b/frontend/src/store/reducers/collection/collection.js
@@ -82,7 +82,9 @@ const reducer = (state = initialState, action) => {
             list: {
                 ...state.selected,
                 status: collectionStatus.SUCCESS,
-                list: action.target,
+                list: action.target.collections,
+                pageNum: action.target.pageNum,
+                finished: action.target.finished,
             },
         };
     case collectionConstants.GET_COLLECTION:

--- a/frontend/src/store/reducers/collection/collection.test.js
+++ b/frontend/src/store/reducers/collection/collection.test.js
@@ -101,10 +101,10 @@ describe("Collection reducer", () => {
     it("should return get_collections", () => {
         const newState = reducer(stubInitialState, {
             type: collectionConstants.GET_COLLECTIONS,
-            target: stubCollection,
+            target: { collections: [stubCollection], pageNum: 1, finished: true },
         });
         expect(newState.list.status).toBe(collectionStatus.SUCCESS);
-        expect(newState.list.list).toBe(stubCollection);
+        expect(newState.list.list).toEqual([stubCollection]);
     });
 
     it("should return get_collection", () => {


### PR DESCRIPTION
Related Issue: #148, #152 
This PR will resolve #152 issue.


# Major changes
I fixed bug that users cannot properly remove papers from their collections. It was due to mistakes on backend codes.

<img width="695" alt="스크린샷 2019-12-05 03 01 45" src="https://user-images.githubusercontent.com/35535636/70168132-9465cc80-170b-11ea-9ce8-affdfee16ea6.png">


I updated AddPaperModal and CollectionList so that they use pagination.

<img width="723" alt="스크린샷 2019-12-05 03 01 58" src="https://user-images.githubusercontent.com/35535636/70168139-9af44400-170b-11ea-896b-9422b4eb251f.png">


# Minor changes
I enabled AddPaperModal, GoMyCollectionsModal, and IntroModal to use onHide(), so that users can close them by clicking places out of the modals.

Fix a minor bug of CollectionDetail.


### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
