### PR TITLE
Collection Histroy 무한 스크롤 버그

### DIFF
--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -317,7 +317,8 @@ def select_collection_like(args):
     params = {
         constants.ORDER_BY: preserved
     }
-    collections, _, is_finished = __get_collections(Q(id__in=collection_ids), request_user, 10, params=params)
+    collections, _, is_finished = __get_collections(Q(id__in=collection_ids), request_user, 10, params=params,
+                                                    page_number=page_number)
 
     return collections, page_number, is_finished
 


### PR DESCRIPTION
Related Issue: #159 
It resolves #159 



# Major changes
def select_collection_like(args): 함수에서 page_number를 이용해 해당 페이지를 받아와야하는데 
파라미터로 page_number를 활용하지않고 있었다. 
넘기도록 수정 완료.


### Checklist
This pull request...
- [ ] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [ ] doesn't include too many changes (you should focus on the specific feature in a PR)
- [ ] elaborately explains what feature is added, which part is fixed or improved
- [ ] has step by step instructions for collaborators, if needed
- [ ] has attached screenshots, if appropriate

My codes...
- [ ] include enough tests for added and changed parts
- [ ] pass all the new and existing tests
- [ ] include appropriate comments
- [ ] don't introduce unnecessary warnings
