### PR TITLE
Fixing Update Problem after Creating Collection & Problems of Recommendation

### DIFF
--- a/backend/papersfeed/utils/recommendations/utils.py
+++ b/backend/papersfeed/utils/recommendations/utils.py
@@ -1,5 +1,6 @@
 """utils.py"""
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from django.db.models import OuterRef, Subquery, F, Q, Count
 from django.core.paginator import Paginator
@@ -83,7 +84,7 @@ def select_recommendation(args):
     request_user = args[constants.USER]
     page_number = 1 if constants.PAGE_NUMBER not in args else int(args[constants.PAGE_NUMBER])
 
-    recommendation_queryset = UserRecommendation.objects.filter(user_id=request_user.id)
+    recommendation_queryset = UserRecommendation.objects.filter(user_id=request_user.id).order_by('rank')
 
     recommendations = get_results_from_queryset(recommendation_queryset, 20, page_number)
 
@@ -127,15 +128,15 @@ def insert_recommendation_init(args):
         else:
             paper_sort = []
 
-        paper_sort += [paper for paper in paper_ids[0:20]]
-        paper_sort = list(set(paper_sort))
+        paper_sort += [paper for paper in paper_ids[:20]]
+        paper_sort = list(OrderedDict.fromkeys(paper_sort))
 
         UserRecommendation.objects.bulk_create([
             UserRecommendation(
                 user_id=request_user.id,
                 paper_id=paper_id,
                 rank=k*10 + i+1,
-            ) for i, paper_id in enumerate(paper_sort[0:10])
+            ) for i, paper_id in enumerate(paper_sort[:10])
         ])
 
 def select_paper_all(args):

--- a/backend/papersfeed/utils/subscriptions/utils.py
+++ b/backend/papersfeed/utils/subscriptions/utils.py
@@ -16,7 +16,7 @@ def select_subscriptions(args):
     """Get Subscriptions of the current User"""
 
     request_user = args[constants.USER]
-    page_number = 1 if constants.PAGE_NUMBER not in args else args[constants.PAGE_NUMBER]
+    page_number = 1 if constants.PAGE_NUMBER not in args else int(args[constants.PAGE_NUMBER])
 
     # get the list of users that this user is following
     followings_queryset = UserFollow.objects.filter(

--- a/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.js
+++ b/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.js
@@ -31,7 +31,7 @@ class CreateNewCollectionModal extends Component {
             text: newCollectionDesc,
         })
             .then(() => {
-                this.props.onUpdateCollection({ id: this.props.me.id });
+                this.props.whatActionWillFollow();
                 this.setState({
                     isModalOpen: false,
                     newCollectionName: "",
@@ -114,19 +114,16 @@ const mapDispatchToProps = (dispatch) => ({
     onCreateNewCollection: (collection) => dispatch(
         collectionActions.makeNewCollection(collection),
     ),
-    onUpdateCollection: (id) => dispatch(collectionActions.getCollectionsByUserId(id)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CreateNewCollectionModal);
 
 CreateNewCollectionModal.propTypes = {
-    me: PropTypes.objectOf(PropTypes.any),
     onCreateNewCollection: PropTypes.func,
-    onUpdateCollection: PropTypes.func,
+    whatActionWillFollow: PropTypes.func,
 };
 
 CreateNewCollectionModal.defaultProps = {
-    me: null,
-    onCreateNewCollection: null,
-    onUpdateCollection: null,
+    onCreateNewCollection: () => {},
+    whatActionWillFollow: () => {},
 };

--- a/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
+++ b/frontend/src/components/Modal/CreateNewCollectionModal/CreateNewCollectionModal.test.js
@@ -17,6 +17,7 @@ const makeCreateNewCollectionModal = (initialState) => (
 describe("CreateNewCollection test", () => {
     let stubInitialState;
     let createNewCollection;
+    let spyMakeNewCollection;
 
     beforeEach(() => {
         stubInitialState = {
@@ -61,6 +62,9 @@ describe("CreateNewCollection test", () => {
             reply: {},
         };
         createNewCollection = makeCreateNewCollectionModal(stubInitialState);
+
+        spyMakeNewCollection = jest.spyOn(collectionActions, "makeNewCollection")
+            .mockImplementation(() => () => mockPromise);
     });
 
     it("should render without errors", () => {
@@ -98,14 +102,6 @@ describe("CreateNewCollection test", () => {
     });
 
     it("should handle making new collection", async () => {
-        // mocking actions
-        /* eslint-disable no-unused-vars */
-        const spyMakeNewCollection = jest.spyOn(collectionActions, "makeNewCollection")
-            .mockImplementation(() => () => mockPromise);
-        const spyGetCollectionsByUserId = jest.spyOn(collectionActions, "getCollectionsByUserId")
-            .mockImplementation(() => () => mockPromise);
-        /* eslint-enable no-unused-vars */
-
         // change state and click button
         const component = mount(createNewCollection);
         let wrapper = component.find("#modalOpenButton").hostNodes();
@@ -124,7 +120,6 @@ describe("CreateNewCollection test", () => {
         await flushPromises();
         component.update();
 
-        expect(spyGetCollectionsByUserId).toHaveBeenCalledTimes(1);
         const instance = component.find("CreateNewCollectionModal").instance();
         expect(instance.state.isModalOpen).toBe(false);
     });

--- a/frontend/src/containers/Collection/CollectionList/CollectionList.js
+++ b/frontend/src/containers/Collection/CollectionList/CollectionList.js
@@ -73,7 +73,12 @@ class CollectionList extends Component {
                 <div className="CollectionListContent">
                     <div id="collectionListText">My Collections</div>
                     <div id="collectionNewButtonDiv">
-                        <CreateNewCollectionModal />
+                        <CreateNewCollectionModal
+                          whatActionWillFollow={() => {
+                              this.setState({ collections: [] });
+                              this.getCollectionsTrigger(0);
+                          }}
+                        />
                     </div>
                     <div id="colletionCards">
                         <div id="collectionCardsLeft">{collectionCardsLeft}</div>

--- a/frontend/src/containers/Subscription/SubscriptionFeed.js
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.js
@@ -52,13 +52,6 @@ class SubscriptionFeed extends Component {
             }).catch(() => {});
     }
 
-    // FIXME: if de-commentize those lines, somehow onGetSubscriptions is called recursively
-    // componentDidUpdate(prevProps) {
-    //     if (this.props.subscriptionItems !== prevProps.subscriptionItems) {
-    //         this.props.onGetSubscriptions();
-    //     }
-    // }
-
     clickMoreButton = () => {
         if (!this.props.subscriptionFinished) {
             this.props.onGetSubscriptions({

--- a/frontend/src/containers/Subscription/SubscriptionFeed.test.js
+++ b/frontend/src/containers/Subscription/SubscriptionFeed.test.js
@@ -12,216 +12,9 @@ import { getMockStore, mockPromise, flushPromises } from "../../test-utils/mocks
 import { history } from "../../store/store";
 import { authActions } from "../../store/actions";
 
-const stubSubscriptions = [
-    {
-        action_object: {
-            content: {
-                count: {
-                    likes: 1,
-                    replies: 0,
-                },
-                creation_date: "2019-12-02T07:31:40.975",
-                id: 2,
-                liked: false,
-                modification_date: "2019-12-02T07:31:40.976",
-                paper: {
-                    DOI: "",
-                    ISSN: "",
-                    abstract: "We explain why semistability of a one-ended proper CAT(0) space can be↵determined by the geodesic rays. This is applied to boundaries of CAT(0)↵groups.",
-                    authors: [{
-                        address: "",
-                        email: "",
-                        first_name: "Ross",
-                        id: 53,
-                        last_name: "Geoghegan",
-                        rank: 1,
-                        researcher_id: "",
-                        type: "general",
-                    }],
-                    count: { reviews: 2, likes: 1 },
-                    download_url: "http://arxiv.org/pdf/1703.07003v1",
-                    eISSN: "",
-                    file_url: "http://arxiv.org/abs/1703.07003v1",
-                    id: 31,
-                    keywords: [],
-                    language: "english",
-                    liked: false,
-                    publication: {},
-                    title: "Semistability and CAT(0) Geometry",
-                },
-                text: "zxcbvzxcb",
-                title: "asfdas",
-                user: {
-                    id: 1,
-                    username: "asdf",
-                    email: "asdf@snu.ac.kr",
-                    description: "",
-                    count: {
-                        follower: 1,
-                        following: 1,
-                    },
-                },
-            },
-            type: "review",
-        },
-        actor: {
-            id: 2,
-            username: "girin",
-        },
-        creation_date: "2019-12-02T07:31:58.980",
-        id: 11,
-        target: {},
-        verb: "liked",
-    },
-    {
-        action_object: {
-            content: {
-                count: {
-                    users: 1,
-                    papers: 0,
-                    likes: 0,
-                    replies: 0,
-                },
-                creation_date: "2019-12-02T05:56:28.856",
-                id: 2,
-                liked: false,
-                modification_date: "2019-12-02T05:56:28.856",
-                text: "meowwww",
-                title: "girin",
-            },
-            type: "collection",
-        },
-        actor: { id: 2, username: "girin" },
-        creation_date: "2019-12-02T05:56:28.864",
-        id: 10,
-        target: {},
-        verb: "created",
-    },
-    {
-        action_object: {
-            type: "paper",
-            content: {
-                DOI: "10.2140/gt.2007.11.1255",
-                ISSN: "",
-                abstract: "This paper ... ",
-                authors: [
-                    {
-                        address: "",
-                        email: "",
-                        first_name: "Michael",
-                        id: 54,
-                        last_name: "Farber",
-                        rank: 1,
-                        researcher_id: "",
-                        type: "general",
-                    },
-                    {
-                        address: "",
-                        email: "",
-                        first_name: "Dirk",
-                        id: 55,
-                        last_name: "Schuetz",
-                        rank: 2,
-                        researcher_id: "",
-                        type: "general",
-                    },
-                ],
-                count: {
-                    reviews: 0,
-                    likes: 1,
-                },
-                download_url: "http://arxiv.org/pdf/math/0609005v1",
-                eISSN: "",
-                file_url: "http://arxiv.org/abs/math/0609005v1",
-                id: 32,
-                keywords: [],
-                language: "english",
-                liked: false,
-                publication: {},
-                title: "Cohomological estimates",
-            },
-        },
-        actor: {
-            id: 2,
-            username: "girin",
-        },
-        creation_date: "2019-12-02T03:41:13.561",
-        id: 9,
-        target: {},
-        verb: "liked",
-    },
-    {
-        action_object: {
-            type: "type that cannot exist",
-            content: {},
-        },
-        creation_date: "2019-12-02T03:41:13.561",
-        id: 9,
-        target: {},
-        verb: "liked",
-    },
-];
-
-const stubRecommendation = [
-    {
-        action_object: {
-            type: "paper",
-            content: {
-                DOI: "10.2140/gt.2007.11.1255",
-                ISSN: "",
-                abstract: "This paper ... ",
-                authors: [
-                    {
-                        address: "",
-                        email: "",
-                        first_name: "Michael",
-                        id: 54,
-                        last_name: "Farber",
-                        rank: 1,
-                        researcher_id: "",
-                        type: "general",
-                    },
-                    {
-                        address: "",
-                        email: "",
-                        first_name: "Dirk",
-                        id: 55,
-                        last_name: "Schuetz",
-                        rank: 2,
-                        researcher_id: "",
-                        type: "general",
-                    },
-                ],
-                count: {
-                    reviews: 0,
-                    likes: 1,
-                },
-                download_url: "http://arxiv.org/pdf/math/0609005v1",
-                eISSN: "",
-                file_url: "http://arxiv.org/abs/math/0609005v1",
-                id: 32,
-                keywords: [],
-                language: "english",
-                liked: false,
-                publication: {},
-                title: "Cohomological estimates",
-            },
-        },
-        actor: {
-            id: 0,
-            username: "papersfeed",
-        },
-        creation_date: "2019-12-02T03:41:13.561",
-        id: 9,
-        target: {},
-        verb: "liked",
-    },
-];
-
 const makeFeed = (initialState, props = {}) => (
     <Provider store={getMockStore(initialState)}>
         <SubscriptionFeed
-          match={{ params: { review_id: 1 } }}
           history={history}
           props={props}
         />
@@ -230,11 +23,172 @@ const makeFeed = (initialState, props = {}) => (
 
 describe("SubscriptionFeed test", () => {
     let feed;
+    let stubSubscriptions;
+    let stubRecommendations;
     let stubInitialState;
     let spyGetRecommendation;
     let spyGetSubscription;
 
     beforeEach(() => {
+        stubSubscriptions = [
+            {
+                action_object: {
+                    type: "review",
+                    content: {
+                        count: {
+                            likes: 1,
+                            replies: 0,
+                        },
+                        id: 2,
+                        liked: false,
+                        paper: {
+                            abstract: "We explain why semistability of a one-ended proper CAT(0) space can be↵determined by the geodesic rays. This is applied to boundaries of CAT(0)↵groups.",
+                            authors: [{
+                                first_name: "Ross",
+                                id: 53,
+                                last_name: "Geoghegan",
+                                rank: 1,
+                            }],
+                            count: { reviews: 2, likes: 1 },
+                            id: 31,
+                            keywords: [],
+                            liked: false,
+                            title: "Semistability and CAT(0) Geometry",
+                        },
+                        text: "zxcbvzxcb",
+                        title: "asfdas",
+                        user: {
+                            id: 1,
+                            username: "asdf",
+                            email: "asdf@snu.ac.kr",
+                            description: "",
+                            count: {
+                                follower: 1,
+                                following: 1,
+                            },
+                        },
+                    },
+                },
+                actor: {
+                    id: 2,
+                    username: "girin",
+                },
+                id: 11,
+                target: {},
+                verb: "liked",
+            },
+            {
+                action_object: {
+                    type: "collection",
+                    content: {
+                        count: {
+                            users: 1,
+                            papers: 0,
+                            likes: 0,
+                            replies: 0,
+                        },
+                        id: 2,
+                        liked: false,
+                        text: "meowwww",
+                        title: "girin",
+                    },
+                },
+                actor: { id: 2, username: "girin" },
+                id: 10,
+                target: {},
+                verb: "created",
+            },
+            {
+                action_object: {
+                    type: "paper",
+                    content: {
+                        abstract: "This paper ... ",
+                        authors: [
+                            {
+                                address: "",
+                                email: "",
+                                first_name: "Michael",
+                                id: 54,
+                                last_name: "Farber",
+                                rank: 1,
+                            },
+                            {
+                                address: "",
+                                email: "",
+                                first_name: "Dirk",
+                                id: 55,
+                                last_name: "Schuetz",
+                                rank: 2,
+                            },
+                        ],
+                        count: {
+                            reviews: 0,
+                            likes: 1,
+                        },
+                        id: 32,
+                        keywords: [],
+                        liked: false,
+                        title: "Cohomological estimates",
+                    },
+                },
+                actor: {
+                    id: 2,
+                    username: "girin",
+                },
+                id: 9,
+                target: {},
+                verb: "liked",
+            },
+            {
+                action_object: {
+                    type: "type that cannot exist",
+                    content: {},
+                },
+                id: 9,
+                target: {},
+                verb: "liked",
+            },
+        ];
+
+        stubRecommendations = [
+            {
+                action_object: {
+                    type: "paper",
+                    content: {
+                        abstract: "This paper ... ",
+                        authors: [
+                            {
+                                first_name: "Michael",
+                                id: 54,
+                                last_name: "Farber",
+                                rank: 1,
+                            },
+                            {
+                                first_name: "Dirk",
+                                id: 55,
+                                last_name: "Schuetz",
+                                rank: 2,
+                            },
+                        ],
+                        count: {
+                            reviews: 0,
+                            likes: 1,
+                        },
+                        id: 32,
+                        keywords: [],
+                        liked: false,
+                        title: "Cohomological estimates",
+                    },
+                },
+                actor: {
+                    id: 0,
+                    username: "papersfeed",
+                },
+                id: 9,
+                target: {},
+                verb: "liked",
+            },
+        ];
         stubInitialState = {
             paper: {},
             auth: {
@@ -252,7 +206,8 @@ describe("SubscriptionFeed test", () => {
                 },
                 recommendations: {
                     status: getRecommendationsStatus.SUCCESS,
-                    list: stubRecommendation,
+                    list: stubRecommendations,
+                    pageNum: 1,
                     finished: true,
                 },
                 keywords: {
@@ -372,16 +327,15 @@ describe("SubscriptionFeed test", () => {
         expect(spyGetRecommendation).toBeCalledTimes(1);
     });
 
-    it("should handle cards well", () => {
+    it("should handle cards well", async () => {
         const component = mount(feed);
-        component.find("SubscriptionFeed").instance().setState({
-            subscriptions: stubSubscriptions,
-            recommendations: stubRecommendation,
-        });
+
+        await flushPromises();
         component.update();
 
         const wrapperLeft = component.find("#subscriptionCardsLeft");
         const wrapperRight = component.find("#subscriptionCardsRight");
+
         expect(component.find("PaperCard").length).toBe(2);
         expect(component.find("CollectionCard").length).toBe(1);
         expect(component.find("ReviewCard").length).toBe(1);
@@ -412,7 +366,7 @@ describe("SubscriptionFeed test", () => {
                 recommendations: {
                     ...stubInitialState.auth.recommendations,
                     finished: false,
-                    list: stubRecommendation,
+                    list: stubRecommendations,
                 },
             },
         };
@@ -422,9 +376,10 @@ describe("SubscriptionFeed test", () => {
         const spyAdd = jest.spyOn(instance, "addRecoToSub");
         expect(spyGetSubscription).toBeCalledTimes(1);
         await flushPromises();
-
+        component.update();
         expect(spyGetRecommendation).toBeCalledTimes(1);
         await flushPromises();
+        component.update();
 
         expect(instance.state.recommendations.length).toBe(0);
         expect(spyAdd).toBeCalledTimes(1);
@@ -457,7 +412,7 @@ describe("SubscriptionFeed test", () => {
                 recommendations: {
                     ...stubInitialState.auth.recommendations,
                     finished: true,
-                    list: stubRecommendation,
+                    list: stubRecommendations,
                 },
             },
         };

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -81,7 +81,6 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             subscriptions: {
-                ...state.subscriptions,
                 status: getSubscriptionsStatus.SUCCESS,
                 list: action.target.subscriptions,
                 pageNum: action.target.page_number,
@@ -92,8 +91,9 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             subscriptions: {
-                ...state.subscriptions,
                 status: getSubscriptionsStatus.FAILURE,
+                list: [],
+                pageNum: 0,
                 finished: true,
             },
         };
@@ -102,7 +102,6 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             recommendations: {
-                ...state.recommendations,
                 status: getRecommendationsStatus.SUCCESS,
                 list: action.target.recommendations,
                 pageNum: action.target.page_number,
@@ -113,8 +112,9 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             recommendations: {
-                ...state.recommendations,
                 status: getRecommendationsStatus.FAILURE,
+                list: [],
+                pageNum: 0,
                 finished: true,
             },
         };
@@ -123,7 +123,6 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             keywords: {
-                ...state.keywords,
                 status: getKeywordsInitStatus.SUCCESS,
                 list: action.target.keywords,
                 pageNum: action.target.page_number,
@@ -134,8 +133,9 @@ const reducer = (state = initialState, action) => {
         return {
             ...state,
             keywords: {
-                ...state.keywords,
                 status: getKeywordsInitStatus.FAILURE,
+                list: [],
+                pageNum: 0,
                 finished: true,
             },
         };


### PR DESCRIPTION
Related Issue: #164, #173, #87
This PR will resolve #164 issue.


# Major changes
I fixed the problem that collection list is not updated after creating a new collection.

I added `int()` conversion to `select_subscriptions`, because disaster can be caused without it.

<img width="400" alt="스크린샷 2019-12-06 04 15 14" src="https://user-images.githubusercontent.com/35535636/70266028-0529e900-17df-11ea-91f3-588803567359.png">

In `insert_recommendation_init()`, we should maintain the ordering of `paper_sort`. I made the code maintain it.

In `select_recommendation()`, it should give recommendation records with lower ranks. I made the code guarantee it.

# Minor changes
I slightly modified the test file of SubscriptionFeed. It seems to need more modification.


### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
