### PR TITLE
Notification Scroll Pagination & True Counts of objects on some pages

### DIFF
--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -326,10 +326,11 @@ def delete_user_collection_pending(args):
 
 def get_notification(args):
     """Get Notification"""
-    notifications, page_number, is_finished = notification_utils.select_notifications(args)
+    notifications, page_number, is_finished, total_count = notification_utils.select_notifications(args)
     return {constants.NOTIFICATIONS: notifications,
             constants.PAGE_NUMBER: page_number,
-            constants.IS_FINISHED: is_finished}
+            constants.IS_FINISHED: is_finished,
+            constants.TOTAL_COUNT: total_count}
 
 
 def put_notification(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -177,10 +177,11 @@ def get_collection_search(args):
 
 def get_user_search(args):
     """Get User Search"""
-    users, page_number, is_finished = users_utils.select_user_search(args)
+    users, page_number, is_finished, total_count = users_utils.select_user_search(args)
     return {constants.USERS: users,
             constants.PAGE_NUMBER: page_number,
-            constants.IS_FINISHED: is_finished}
+            constants.IS_FINISHED: is_finished,
+            constants.TOTAL_COUNT: total_count}
 
 
 def post_like_paper(args):

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -151,10 +151,11 @@ def get_review_paper(args):
 
 def get_review_user(args):
     """Get Review User"""
-    reviews, page_number, is_finished = reviews_utils.select_review_user(args)
+    reviews, page_number, is_finished, total_count = reviews_utils.select_review_user(args)
     return {constants.REVIEWS: reviews,
             constants.PAGE_NUMBER: page_number,
-            constants.IS_FINISHED: is_finished}
+            constants.IS_FINISHED: is_finished,
+            constants.TOTAL_COUNT: total_count}
 
 
 def get_paper_search(args):
@@ -167,10 +168,11 @@ def get_paper_search(args):
 
 def get_collection_search(args):
     """Get Collection Search"""
-    collections, page_number, is_finished = collections_utils.select_collection_search(args)
+    collections, page_number, is_finished, total_count = collections_utils.select_collection_search(args)
     return {constants.COLLECTIONS: collections,
             constants.PAGE_NUMBER: page_number,
-            constants.IS_FINISHED: is_finished}
+            constants.IS_FINISHED: is_finished,
+            constants.TOTAL_COUNT: total_count}
 
 
 def get_user_search(args):

--- a/backend/papersfeed/utils/collections/utils.py
+++ b/backend/papersfeed/utils/collections/utils.py
@@ -303,9 +303,13 @@ def select_collection_search(args):
                                                                              | Q(is_member=True))
 
     # Collections
-    collections, _, is_finished, _ = __get_collections(queryset, request_user, 10, page_number=page_number)
+    params = {
+        constants.TOTAL_COUNT: True # count whole collections
+    }
+    collections, _, is_finished, total_count = __get_collections(queryset, request_user, 10, params=params,
+                                                                 page_number=page_number)
 
-    return collections, page_number, is_finished
+    return collections, page_number, is_finished, total_count
 
 
 def select_collection_like(args):

--- a/backend/papersfeed/utils/notifications/utils.py
+++ b/backend/papersfeed/utils/notifications/utils.py
@@ -24,13 +24,15 @@ def select_notifications(args):
     # Notification QuerySet
     queryset = user.notifications.unread().filter(~Q(actor_object_id=request_user.id))
 
+    total_count = queryset.count()
+
     notifications = get_results_from_queryset(queryset, 10, page_number)
 
     is_finished = not notifications.has_next()
 
     notifications = __pack_notifications(notifications)
 
-    return notifications, page_number, is_finished
+    return notifications, page_number, is_finished, total_count
 
 
 def read_notification(args):

--- a/backend/papersfeed/utils/replies/utils.py
+++ b/backend/papersfeed/utils/replies/utils.py
@@ -289,7 +289,7 @@ def __pack_replies(replies, request_user):
 
     # Users
     user_ids = [reply.user_id for reply in replies]
-    users, _ = users_utils.get_users(Q(id__in=user_ids), request_user, None)
+    users, _, _ = users_utils.get_users(Q(id__in=user_ids), request_user, None)
 
     # {user_id: user}
     users = {user[constants.ID]: user for user in users}
@@ -309,7 +309,7 @@ def __pack_replies(replies, request_user):
         reply_id__in=reply_ids
     )
     review_ids = [reply.review_id for reply in review_replies]
-    reviews, _, _ = reviews_utils.get_reviews(Q(id__in=review_ids), request_user, None)
+    reviews, _, _, _ = reviews_utils.get_reviews(Q(id__in=review_ids), request_user, None)
     # {review_id: review}
     reviews = {review[constants.ID]: review for review in reviews}
 

--- a/backend/papersfeed/utils/reviews/utils.py
+++ b/backend/papersfeed/utils/reviews/utils.py
@@ -29,7 +29,7 @@ def select_review(args):
     request_user = args[constants.USER]
 
     # Reviews
-    reviews, _, _ = __get_reviews(Q(id=review_id), request_user, None)
+    reviews, _, _, _ = __get_reviews(Q(id=review_id), request_user, None)
 
     # Not Exists
     if not reviews:
@@ -113,7 +113,7 @@ def insert_review(args):
             count=1,
         )
 
-    reviews, _, _ = __get_reviews(Q(id=review.id), request_user, None)
+    reviews, _, _, _ = __get_reviews(Q(id=review.id), request_user, None)
 
     if not reviews:
         raise ApiError(constants.NOT_EXIST_OBJECT)
@@ -167,7 +167,7 @@ def update_review(args):
 
     review.save()
 
-    reviews, _, _ = __get_reviews(Q(id=review.id), request_user, None)
+    reviews, _, _, _ = __get_reviews(Q(id=review.id), request_user, None)
 
     if not reviews:
         raise ApiError(constants.NOT_EXIST_OBJECT)
@@ -229,7 +229,7 @@ def select_review_paper(args):
     # Reviews Queryset
     queryset = Q(paper_id=paper_id)
 
-    reviews, _, is_finished = __get_reviews(queryset, request_user, 10, page_number=page_number)
+    reviews, _, is_finished, _ = __get_reviews(queryset, request_user, 10, page_number=page_number)
 
     return reviews, page_number, is_finished
 
@@ -255,9 +255,13 @@ def select_review_user(args):
     else:
         queryset = Q(user_id=user_id) & Q(anonymous=False)
 
-    reviews, _, is_finished = __get_reviews(queryset, request_user, 10, page_number=page_number)
+    params = {
+        constants.TOTAL_COUNT: True # count whole reviews
+    }
+    reviews, _, is_finished, total_count = __get_reviews(queryset, request_user, 10, params=params,
+                                                         page_number=page_number)
 
-    return reviews, page_number, is_finished
+    return reviews, page_number, is_finished, total_count
 
 
 def select_review_like(args):
@@ -277,8 +281,11 @@ def select_review_like(args):
     preserved = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(review_ids)])
 
     # Reviews
-    reviews, _, is_finished = __get_reviews(Q(id__in=review_ids), request_user, 10, order_by=preserved,
-                                            page_number=page_number)
+    params = {
+        constants.ORDER_BY: preserved
+    }
+    reviews, _, is_finished, _ = __get_reviews(Q(id__in=review_ids), request_user, 10, params=params,
+                                               page_number=page_number)
 
     return reviews, page_number, is_finished
 
@@ -287,17 +294,24 @@ def get_reviews(filter_query, request_user, count, page_number=1):
     """Get Reviews"""
     return __get_reviews(filter_query, request_user, count, page_number=page_number)
 
+
 def get_review_like_count(review_ids, group_by_field):
     """Get Review like Count"""
     return __get_review_like_count(review_ids, group_by_field)
 
-def __get_reviews(filter_query, request_user, count, page_number=1, order_by='-pk'):
+
+def __get_reviews(filter_query, request_user, count, params=None, page_number=1):
     """Get Reviews By Query"""
+    params = {} if params is None else params
+    order_by = '-pk' if constants.ORDER_BY not in params else params[constants.ORDER_BY]
+
     queryset = Review.objects.filter(
         filter_query
     ).annotate(
         is_liked=__is_review_liked('id', request_user)
     ).order_by(order_by)
+
+    total_count = queryset.count() if constants.TOTAL_COUNT in params else None
 
     reviews = get_results_from_queryset(queryset, count, page_number)
 
@@ -309,7 +323,7 @@ def __get_reviews(filter_query, request_user, count, page_number=1, order_by='-p
 
     reviews = __pack_reviews(reviews, request_user)
 
-    return reviews, pagination_value, is_finished
+    return reviews, pagination_value, is_finished, total_count
 
 
 # pylint: disable-msg=too-many-locals

--- a/backend/papersfeed/utils/reviews/utils.py
+++ b/backend/papersfeed/utils/reviews/utils.py
@@ -337,7 +337,7 @@ def __pack_reviews(reviews, request_user):
 
     # Users
     user_ids = [review.user_id for review in reviews]
-    users, _ = users_utils.get_users(Q(id__in=user_ids), request_user, None)
+    users, _, _ = users_utils.get_users(Q(id__in=user_ids), request_user, None)
 
     # {user_id: user}
     users = {user[constants.ID]: user for user in users}

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -29,7 +29,7 @@ class Header extends Component {
     }
 
     componentDidMount() {
-        this.props.onGetNoti()
+        this.props.onGetNoti(0)
             .then(() => {})
             .catch(() => {});
     }
@@ -180,12 +180,14 @@ class Header extends Component {
 const mapStateToProps = (state) => ({
     me: state.auth.me,
     signoutStatus: state.auth.signoutStatus,
-    notifications: state.auth.notifications,
+    notifications: state.auth.notifications.notifications,
+    notiPageNum: state.auth.notifications.pageNum,
+    notiFinished: state.auth.notifications.finished,
 });
 
 const mapDispatchToProps = (dispatch) => ({
     onSignout: () => dispatch(authActions.signout()),
-    onGetNoti: () => dispatch(authActions.getNoti()),
+    onGetNoti: (pageNum) => dispatch(authActions.getNoti(pageNum)),
     onReadNoti: (notificationId) => dispatch(authActions.readNoti(notificationId)),
 });
 

--- a/frontend/src/components/Header/Header.js
+++ b/frontend/src/components/Header/Header.js
@@ -2,9 +2,7 @@ import React, { Component } from "react";
 import {
     Navbar, Form, Dropdown, Button, Nav, Badge,
 } from "react-bootstrap";
-
 import { Link, withRouter } from "react-router-dom";
-
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 
@@ -20,8 +18,17 @@ class Header extends Component {
 
         this.state = {
             searchWord: "",
+            openNoti: false,
+            notiLoading: true,
+            notifications: [],
+            newNotifications: [],
+            notiPageNum: 0,
+            notiFinished: true,
         };
 
+        this.notiMenu = React.createRef();
+        this.handleScroll = this.handleScroll.bind(this);
+        this.openNoti = this.openNoti.bind(this);
         this.keyPressHandler = this.keyPressHandler.bind(this);
         this.handleChange = this.handleChange.bind(this);
         this.clickSignoutButtonHandler = this.clickSignoutButtonHandler.bind(this);
@@ -29,8 +36,20 @@ class Header extends Component {
     }
 
     componentDidMount() {
-        this.props.onGetNoti(0)
-            .then(() => {})
+        this.props.onGetNoti(0);
+    }
+
+    getNotiTrigger(pageNum) {
+        this.props.onGetNoti(pageNum + 1)
+            .then(() => {
+                const { notifications } = this.state;
+                this.setState({
+                    notifications: notifications.concat(this.props.notifications),
+                    notiPageNum: this.props.notiPageNum,
+                    notiFinished: this.props.notiFinished,
+                    notiLoading: false,
+                });
+            })
             .catch(() => {});
     }
 
@@ -39,6 +58,68 @@ class Header extends Component {
             this.props.history.push(`/search=${this.state.searchWord}`);
         }
     };
+
+    handleScroll = () => {
+        const { scrollHeight } = this.notiMenu.current.childNodes[1];
+        const { scrollTop } = this.notiMenu.current.childNodes[1];
+        const { clientHeight } = this.notiMenu.current.childNodes[1];
+
+        if (!this.state.notiLoading
+            && !this.state.notiFinished
+            && ((scrollTop + clientHeight + 50)
+            > scrollHeight)) {
+            this.setState({
+                notiLoading: true,
+            });
+            this.getNotiTrigger(this.state.notiPageNum);
+        }
+    }
+
+    openNoti() {
+        if (!this.state.openNoti) {
+            this.getNotiTrigger(0);
+            this.setState({ openNoti: true });
+            this.notiMenu.current.childNodes[1].addEventListener("scroll", this.handleScroll);
+        } else {
+            this.notiMenu.current.childNodes[1].removeEventListener("scroll", this.handleScroll);
+            this.setState({
+                openNoti: false,
+                notifications: [],
+                newNotifications: [],
+                notiPageNum: 0,
+                notiFinished: true,
+            });
+        }
+    }
+
+    /* eslint-disable no-await-in-loop */
+    async handleNotis() {
+        // get notifications until previous pageCount
+        const end = this.state.notiPageNum;
+        this.setState({
+            newNotifications: [],
+        });
+        for (let i = 1; (i === 1) || (i < end + 1); i += 1) {
+            await this.forEachHandleNoti(i, end);
+            if (i === end || this.props.notiFinished === true) {
+                this.setState((prevState) => ({
+                    notifications: prevState.newNotifications.concat(this.props.notifications),
+                    notiPageNum: this.props.notiPageNum,
+                    newNotifications: [],
+                    notiFinished: this.props.notiFinished,
+                }));
+                break;
+            }
+            this.setState((prevState) => ({
+                newNotifications: prevState.newNotifications.concat(this.props.notifications),
+            }));
+        }
+    }
+    /* eslint-enable no-await-in-loop */
+
+    forEachHandleNoti(i) {
+        return this.props.onGetNoti(i);
+    }
 
     // for search input change
     handleChange(e) {
@@ -61,7 +142,7 @@ class Header extends Component {
     readNotiHandler(notificationId) {
         this.props.onReadNoti({ id: notificationId })
             .then(() => {
-                this.props.onGetNoti();
+                this.handleNotis();
             })
             .catch(() => {});
     }
@@ -84,8 +165,8 @@ class Header extends Component {
         }
 
         let notifications = null;
-        if (this.props.notifications.length > 0) {
-            notifications = this.props.notifications.map(
+        if (this.state.notifications.length > 0) {
+            notifications = this.state.notifications.map(
                 (notification) => {
                     let target = null;
                     let targetLink = "";
@@ -147,10 +228,10 @@ class Header extends Component {
                         </Button>
                     </div>
                     <div className="header-buttons">
-                        <Dropdown className="dropdown-notification" alignRight>
+                        <Dropdown ref={this.notiMenu} className="dropdown-notification" alignRight onToggle={() => this.openNoti()}>
                             <Dropdown.Toggle className="notification-button" variant="light" title="notification">
                                 <SVG name="bell" height="20px" width="20px" />
-                                <Badge variant="secondary">{notifications.length}</Badge>
+                                <Badge variant="secondary">{this.props.notiTotalCount}</Badge>
                             </Dropdown.Toggle>
                             <Dropdown.Menu className="notification-menu">
                                 {notifications}
@@ -181,6 +262,7 @@ const mapStateToProps = (state) => ({
     notifications: state.auth.notifications.notifications,
     notiPageNum: state.auth.notifications.pageNum,
     notiFinished: state.auth.notifications.finished,
+    notiTotalCount: state.auth.notifications.totalCount,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -199,6 +281,9 @@ Header.propTypes = {
     onReadNoti: PropTypes.func,
     signoutStatus: PropTypes.string,
     notifications: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)),
+    notiPageNum: PropTypes.number,
+    notiFinished: PropTypes.bool,
+    notiTotalCount: PropTypes.number,
 };
 
 Header.defaultProps = {
@@ -209,4 +294,7 @@ Header.defaultProps = {
     onReadNoti: () => {},
     signoutStatus: signoutStatus.NONE,
     notifications: [],
+    notiPageNum: 0,
+    notiFinished: true,
+    notiTotalCount: 0,
 };

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -5,8 +5,8 @@ import { Route, Switch, Router } from "react-router-dom";
 import { ConnectedRouter } from "connected-react-router";
 
 import { authActions } from "../../store/actions";
-import { signoutStatus } from "../../constants/constants";
-import { getMockStore } from "../../test-utils/mocks";
+import { signoutStatus, notiStatus } from "../../constants/constants";
+import { getMockStore, flushPromises } from "../../test-utils/mocks";
 import Header from "./Header";
 import { history } from "../../store/store";
 
@@ -41,6 +41,14 @@ describe("<Header />", () => {
             auth: {
                 singoutStatus: signoutStatus.NONE,
                 me: null,
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
+                },
             },
             paper: {},
             user: {},
@@ -68,52 +76,77 @@ describe("<Header />", () => {
         expect(spyGetNoti).toHaveBeenCalledTimes(1);
     });
 
-    it("should render notifications properly", () => {
+    it("should render notifications properly", async () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
-                notifications: [{
-                    id: 1,
-                    actor: { id: 1, username: "user1" },
-                    verb: "liked",
-                    target: { type: "review", id: 1, string: "review_title" },
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [{
+                        id: 1,
+                        actor: { id: 1, username: "user1" },
+                        verb: "liked",
+                        target: { type: "review", id: 1, string: "review_title" },
+                    },
+                    {
+                        id: 2,
+                        actor: { id: 1, username: "user1" },
+                        verb: "liked",
+                        target: { type: "collection", id: 1, string: "collection_title" },
+                    },
+                    {
+                        id: 3,
+                        actor: { id: 1, username: "user1" },
+                        verb: "started following you",
+                        target: { type: "user", id: 1, string: "user2" },
+                    },
+                    ],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
                 },
-                {
-                    id: 2,
-                    actor: { id: 1, username: "user1" },
-                    verb: "liked",
-                    target: { type: "collection", id: 1, string: "collection_title" },
-                },
-                {
-                    id: 3,
-                    actor: { id: 1, username: "user1" },
-                    verb: "started following you",
-                    target: { type: "user", id: 1, string: "user2" },
-                },
-                ],
             },
         };
         header = makeHeader(stubInitialState);
         const component = mount(header);
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.openNoti();
+        await flushPromises();
+        component.update();
+
         const wrapper = component.find(".notification-entry");
         expect(wrapper.length).toBe(3);
     });
 
-    it("should call readNoti if read-button is clicked", () => {
+    it("should call readNoti if read-button is clicked", async () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
-                notifications: [{
-                    id: 1,
-                    actor: { id: 1, username: "user1" },
-                    verb: "liked",
-                    target: { type: "review", id: 1, string: "review_title" },
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [{
+                        id: 1,
+                        actor: { id: 1, username: "user1" },
+                        verb: "liked",
+                        target: { type: "review", id: 1, string: "review_title" },
+                    },
+                    ],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
                 },
-                ],
             },
         };
         header = makeHeader(stubInitialState);
         const component = mount(header);
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.openNoti();
+        await flushPromises();
+        component.update();
 
         const wrapper = component.find(".read-button");
         expect(wrapper.length).toBe(1);
@@ -122,21 +155,33 @@ describe("<Header />", () => {
         expect(spyReadNoti).toHaveBeenCalledTimes(1);
     });
 
-    it("should not call readNoti if actor-link is clicked", () => {
+    it("should not call readNoti if actor-link is clicked", async () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
-                notifications: [{
-                    id: 1,
-                    actor: { id: 1, username: "user1" },
-                    verb: "liked",
-                    target: { type: "review", id: 1, string: "review_title" },
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [{
+                        id: 1,
+                        actor: { id: 1, username: "user1" },
+                        verb: "liked",
+                        target: { type: "review", id: 1, string: "review_title" },
+                    },
+                    ],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
                 },
-                ],
             },
         };
         header = makeHeader(stubInitialState);
         const component = mount(header);
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.openNoti();
+        await flushPromises();
+        component.update();
 
         const wrapper = component.find("#actor-link").hostNodes();
         expect(wrapper.length).toBe(1);
@@ -145,21 +190,33 @@ describe("<Header />", () => {
         expect(spyReadNoti).toHaveBeenCalledTimes(0);
     });
 
-    it("should call not readNoti if target-link is clicked", () => {
+    it("should call not readNoti if target-link is clicked", async () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
-                notifications: [{
-                    id: 1,
-                    actor: { id: 1, username: "user1" },
-                    verb: "liked",
-                    target: { type: "review", id: 1, string: "review_title" },
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [{
+                        id: 1,
+                        actor: { id: 1, username: "user1" },
+                        verb: "liked",
+                        target: { type: "review", id: 1, string: "review_title" },
+                    },
+                    ],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
                 },
-                ],
             },
         };
         header = makeHeader(stubInitialState);
         const component = mount(header);
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.openNoti();
+        await flushPromises();
+        component.update();
 
         const wrapper = component.find("#target-link").hostNodes();
         expect(wrapper.length).toBe(1);
@@ -185,6 +242,7 @@ describe("<Header />", () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
+                ...stubInitialState.auth,
                 signoutStatus: signoutStatus.SUCCESS,
             },
         };
@@ -200,6 +258,7 @@ describe("<Header />", () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
+                ...stubInitialState.auth,
                 signoutStatus: signoutStatus.FAILURE,
             },
         };
@@ -215,6 +274,7 @@ describe("<Header />", () => {
         stubInitialState = {
             ...stubInitialState,
             auth: {
+                ...stubInitialState.auth,
                 signoutStatus: signoutStatus.FAILURE,
                 me: { username: "swpp" },
             },

--- a/frontend/src/components/Header/Header.test.js
+++ b/frontend/src/components/Header/Header.test.js
@@ -153,6 +153,8 @@ describe("<Header />", () => {
         wrapper.simulate("click");
 
         expect(spyReadNoti).toHaveBeenCalledTimes(1);
+
+        instance.openNoti();
     });
 
     it("should not call readNoti if actor-link is clicked", async () => {
@@ -296,5 +298,44 @@ describe("<Header />", () => {
 
         wrapper.simulate("keypress", { charCode: 13 });
         expect(spyPush).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle scroll", () => {
+        const ref = { current: { scrollTop: 700, clientHeight: 800, scrollHeight: 500 } };
+        const spyCreateRef = jest.spyOn(React, "createRef")
+            .mockImplementation(() => ref);
+        const component = mount(makeHeader(stubInitialState));
+        expect(spyCreateRef).toHaveBeenCalled();
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.setState({
+            openNoti: true, notiLoading: false, notiFinished: false,
+        });
+        component.update();
+
+        instance.handleScroll();
+
+        expect(spyGetNoti).toHaveBeenCalled();
+    });
+
+    it("should not handle scroll", () => {
+        const ref = { current: { scrollTop: 0, clientHeight: 0, scrollHeight: 500 } };
+        const spyCreateRef = jest.spyOn(React, "createRef")
+            .mockImplementation(() => ref);
+        const component = mount(makeHeader(stubInitialState));
+        expect(spyCreateRef).toHaveBeenCalled();
+
+        const instance = component.find(Header.WrappedComponent).instance();
+        instance.setState({
+            openNoti: true, notiLoading: false, notiFinished: true,
+        });
+
+        component.update();
+
+        expect(spyGetNoti).toBeCalledTimes(1);
+        instance.handleScroll();
+
+        expect(spyCreateRef).toBeCalledTimes(1);
+        expect(spyGetNoti).toBeCalledTimes(1);
     });
 });

--- a/frontend/src/containers/Review/ReviewDetail/ReviewDetail.js
+++ b/frontend/src/containers/Review/ReviewDetail/ReviewDetail.js
@@ -77,7 +77,7 @@ class ReviewDetail extends Component {
     }
 
     async handleReplies() {
-        // get replies utile previous pageCount
+        // get replies until previous pageCount
         const end = this.state.replyPageCount;
         this.setState({
             newReplies: [],

--- a/frontend/src/containers/SearchResult/SearchResult.js
+++ b/frontend/src/containers/SearchResult/SearchResult.js
@@ -305,7 +305,6 @@ class SearchResult extends Component {
                 No users.
             </div>
         );
-        let paperPlus = "";
 
         if (this.state.collections.length > 0) {
             collectionCardsLeft = this.state.collections
@@ -328,10 +327,7 @@ class SearchResult extends Component {
         }
 
         let paperMoreButton = null;
-        if (this.state.searchPaperStatus !== paperStatus.WAITING
-            && !this.props.paperFinished) {
-            paperPlus = "+";
-        } else if (this.state.searchPaperStatus === paperStatus.WAITING
+        if (this.state.searchPaperStatus === paperStatus.WAITING
             && !paperEmpty) {
             paperMoreButton = (
                 <div className="alert alert-info" role="alert">
@@ -359,7 +355,7 @@ class SearchResult extends Component {
                         <Tab
                           className="paper-tab"
                           eventKey="paper-tab"
-                          title={`Paper(${this.state.paperIds.length + paperPlus})`}
+                          title={`Paper`}
                         >
                             {paperMessage}
                             <div id="paper-cards">

--- a/frontend/src/containers/SearchResult/SearchResult.js
+++ b/frontend/src/containers/SearchResult/SearchResult.js
@@ -355,7 +355,7 @@ class SearchResult extends Component {
                         <Tab
                           className="paper-tab"
                           eventKey="paper-tab"
-                          title={`Paper`}
+                          title="Paper"
                         >
                             {paperMessage}
                             <div id="paper-cards">

--- a/frontend/src/containers/SearchResult/SearchResult.js
+++ b/frontend/src/containers/SearchResult/SearchResult.js
@@ -306,8 +306,6 @@ class SearchResult extends Component {
             </div>
         );
         let paperPlus = "";
-        let collectionPlus = "";
-        let userPlus = "";
 
         if (this.state.collections.length > 0) {
             collectionCardsLeft = this.state.collections
@@ -342,13 +340,6 @@ class SearchResult extends Component {
             );
         }
 
-        if (!this.props.collectionFinished) {
-            collectionPlus = "+";
-        }
-        if (!this.props.userFinished) {
-            userPlus = "+";
-        }
-
         return (
             <div className="search-result">
                 <div className="item-list">
@@ -380,7 +371,7 @@ class SearchResult extends Component {
                         <Tab
                           className="collection-tab"
                           eventKey="collection-tab"
-                          title={`Collection(${this.state.collections.length + collectionPlus})`}
+                          title={`Collection(${this.props.collectionTotalCount})`}
                         >
                             {collectionMessage}
                             <div id="collection-cards">
@@ -391,7 +382,7 @@ class SearchResult extends Component {
                         <Tab
                           className="user-tab"
                           eventKey="user-tab"
-                          title={`People(${this.state.users.length + userPlus})`}
+                          title={`People(${this.props.userTotalCount})`}
                         >
                             {userMessage}
                             <div id="user-cards">
@@ -419,6 +410,8 @@ const mapStateToProps = (state) => ({
     collectionFinished: state.collection.list.finished,
     userPageNum: state.user.search.pageNum,
     userFinished: state.user.search.finished,
+    collectionTotalCount: state.collection.list.totalCount,
+    userTotalCount: state.user.search.totalCount,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -446,6 +439,8 @@ SearchResult.propTypes = {
     collectionFinished: PropTypes.bool,
     userPageNum: PropTypes.number,
     userFinished: PropTypes.bool,
+    collectionTotalCount: PropTypes.number,
+    userTotalCount: PropTypes.number,
 };
 
 SearchResult.defaultProps = {
@@ -463,4 +458,6 @@ SearchResult.defaultProps = {
     collectionFinished: true,
     userPageNum: 0,
     userFinished: true,
+    collectionTotalCount: 0,
+    userTotalCount: 0,
 };

--- a/frontend/src/containers/User/ProfileDetail/ProfileDetail.js
+++ b/frontend/src/containers/User/ProfileDetail/ProfileDetail.js
@@ -158,10 +158,6 @@ class ProfileDetail extends Component {
     }
 
     render() {
-        const reviewCount = (this.props.reviews.pageNum > 1
-            || (this.props.reviews.pageNum === 1 && this.props.reviews.finished === false))
-            ? "10+" : this.props.reviews.list.length;
-
         const settingButton = (
             <Link to="/account_setting">
                 <Button id="settingButton">Setting</Button>
@@ -263,7 +259,7 @@ class ProfileDetail extends Component {
                                         </Button>
                                     )}
                             </Tab>
-                            <Tab eventKey="reviewTab" title={`Review(${reviewCount})`}>
+                            <Tab eventKey="reviewTab" title={`Review(${this.props.reviews.totalCount})`}>
                                 <div id="reviewCards">
                                     <div id="reviewCardsLeft">{reviewCardsLeft}</div>
                                     <div id="reviewCardsRight">{reviewCardsRight}</div>

--- a/frontend/src/store/actions/auth/auth.js
+++ b/frontend/src/store/actions/auth/auth.js
@@ -87,9 +87,9 @@ export const getMe = () => (dispatch) => axios.get("/api/user/me")
     .catch((err) => dispatch(getMeFailure(err)));
 
 
-const getNotiSuccess = (notifications) => ({
+const getNotiSuccess = (data) => ({
     type: authConstants.GET_NOTI_SUCCESS,
-    target: notifications.notifications,
+    target: data,
 });
 
 const getNotiFailure = (error) => ({
@@ -97,7 +97,7 @@ const getNotiFailure = (error) => ({
     target: error,
 });
 
-export const getNoti = () => (dispatch) => axios.get("/api/notification")
+export const getNoti = (pageNum) => (dispatch) => axios.get("/api/notification", { params: { page_number: pageNum } })
     .then((res) => dispatch(getNotiSuccess(res.data)))
     .catch((err) => dispatch(getNotiFailure(err)));
 

--- a/frontend/src/store/actions/auth/auth.test.js
+++ b/frontend/src/store/actions/auth/auth.test.js
@@ -28,10 +28,15 @@ describe("authActions", () => {
                 signinStatus: signinStatus.NONE,
                 signoutStatus: signoutStatus.NONE,
                 getMeStatus: getMeStatus.NONE,
-                getNotiStatus: notiStatus.NONE,
-                readNotiStatus: notiStatus.NONE,
                 getSubscriptionsStatus: getSubscriptionsStatus.NONE,
-                notifications: [],
+                notifications: {
+                    getStatus: notiStatus.NONE,
+                    readStatus: notiStatus.NONE,
+                    notifications: [],
+                    pageNum: 0,
+                    finished: true,
+                    totalCount: 0,
+                },
                 subscriptions: [],
                 me: null,
             },
@@ -286,9 +291,9 @@ describe("authActions", () => {
                 resolve(result);
             }));
 
-        mockStore.dispatch(authActions.getNoti())
+        mockStore.dispatch(authActions.getNoti(1))
             .then(() => {
-                expect(spy).toHaveBeenCalledWith("/api/notification");
+                expect(spy).toHaveBeenCalledWith("/api/notification", { params: { page_number: 1 } });
                 done();
             });
     });
@@ -305,9 +310,9 @@ describe("authActions", () => {
                 reject(error);
             }));
 
-        mockStore.dispatch(authActions.getNoti())
+        mockStore.dispatch(authActions.getNoti(1))
             .then(() => {
-                expect(spy).toHaveBeenCalledWith("/api/notification");
+                expect(spy).toHaveBeenCalledWith("/api/notification", { params: { page_number: 1 } });
                 done();
             });
     });

--- a/frontend/src/store/actions/collection/collection.js
+++ b/frontend/src/store/actions/collection/collection.js
@@ -339,6 +339,7 @@ const searchCollectionSuccess = (data) => ({
         collections: data.collections,
         pageNum: data.page_number,
         finished: data.is_finished,
+        totalCount: data.total_count,
     },
 });
 

--- a/frontend/src/store/actions/review/review.js
+++ b/frontend/src/store/actions/review/review.js
@@ -46,10 +46,10 @@ export const getReviewsByPaperId = (paperId, pageNum) => (dispatch) => axios.get
     .catch((err) => dispatch(getReviewsByPaperIdFailure(err)));
 
 // get rviews by user id
-const getReviewsByUserIdSuccess = (reviews) => (
+const getReviewsByUserIdSuccess = (data) => (
     {
         type: reviewConstants.GET_REVIEWS_BY_USER,
-        target: reviews,
+        target: data,
     }
 );
 

--- a/frontend/src/store/actions/user/user.js
+++ b/frontend/src/store/actions/user/user.js
@@ -129,7 +129,12 @@ export const editUserInfo = (newUserInfo) => (dispatch) => axios.put("/api/user"
 
 const searchUserSuccess = (data) => ({
     type: userConstants.SEARCH_USER_SUCCESS,
-    target: { users: data.users, pageNum: data.page_number, finished: data.is_finished },
+    target: {
+        users: data.users,
+        pageNum: data.page_number,
+        finished: data.is_finished,
+        totalCount: data.total_count,
+    },
 });
 
 const searchUserFailure = (error) => ({

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -16,8 +16,6 @@ const initialState = {
     signinStatus: signinStatus.NONE,
     signoutStatus: signoutStatus.NONE,
     getMeStatus: getMeStatus.NONE,
-    getNotiStatus: notiStatus.NONE,
-    readNotiStatus: notiStatus.NONE,
     subscriptions: {
         status: getSubscriptionsStatus.NONE,
         pageNum: 0,
@@ -37,7 +35,13 @@ const initialState = {
         finished: true,
     },
     makeTasteInitStatus: makeTasteInitStatus.NONE,
-    notifications: [],
+    notifications: {
+        getStatus: notiStatus.NONE,
+        readStatus: notiStatus.NONE,
+        notifications: [],
+        pageNum: 0,
+        finished: true,
+    },
     me: null,
 };
 
@@ -68,14 +72,41 @@ const reducer = (state = initialState, action) => {
         return { ...state, getMeStatus: getMeStatus.FAILURE };
 
     case authConstants.GET_NOTI_SUCCESS:
-        return { ...state, getNotiStatus: notiStatus.SUCCESS, notifications: action.target };
+        return {
+            ...state,
+            notifications: {
+                ...state.notifications,
+                getStatus: notiStatus.SUCCESS,
+                notifications: action.target.notifications,
+                pageNum: action.target.page_number,
+                finished: action.target.is_finished,
+            },
+        };
     case authConstants.GET_NOTI_FAILURE:
-        return { ...state, getNotiStatus: notiStatus.FAILURE };
+        return {
+            ...state,
+            notifications: {
+                ...state.notifications,
+                getStatus: notiStatus.FAILURE,
+            },
+        };
 
     case authConstants.READ_NOTI_SUCCESS:
-        return { ...state, readNotiStatus: notiStatus.SUCCESS };
+        return {
+            ...state,
+            notifications: {
+                ...state.notifications,
+                readStatus: notiStatus.SUCCESS,
+            },
+        };
     case authConstants.READ_NOTI_FAILURE:
-        return { ...state, readNotiStatus: notiStatus.FAILURE };
+        return {
+            ...state,
+            notifications: {
+                ...state.notifications,
+                readStatus: notiStatus.FAILURE,
+            },
+        };
 
     case authConstants.GET_SUBSCRIPTION_SUCCESS:
         return {

--- a/frontend/src/store/reducers/auth/auth.js
+++ b/frontend/src/store/reducers/auth/auth.js
@@ -41,6 +41,7 @@ const initialState = {
         notifications: [],
         pageNum: 0,
         finished: true,
+        totalCount: 0,
     },
     me: {},
 };
@@ -80,6 +81,7 @@ const reducer = (state = initialState, action) => {
                 notifications: action.target.notifications,
                 pageNum: action.target.page_number,
                 finished: action.target.is_finished,
+                totalCount: action.target.total_count,
             },
         };
     case authConstants.GET_NOTI_FAILURE:

--- a/frontend/src/store/reducers/auth/auth.test.js
+++ b/frontend/src/store/reducers/auth/auth.test.js
@@ -17,8 +17,6 @@ const stubInitialState = {
     signinStatus: signinStatus.NONE,
     signoutStatus: signoutStatus.NONE,
     getMeStatus: getMeStatus.NONE,
-    getNotiStatus: notiStatus.NONE,
-    readNotiStatus: notiStatus.NONE,
     subscriptions: {
         status: getSubscriptionsStatus.NONE,
         pageNum: 0,
@@ -38,7 +36,14 @@ const stubInitialState = {
         finished: true,
     },
     makeTasteInitStatus: makeTasteInitStatus.NONE,
-    notifications: [],
+    notifications: {
+        getStatus: notiStatus.NONE,
+        readStatus: notiStatus.NONE,
+        notifications: [],
+        pageNum: 0,
+        finished: true,
+        totalCount: 0,
+    },
     me: null,
 };
 
@@ -173,12 +178,17 @@ describe("Auth reducer", () => {
     it("should process getNotifications", () => {
         const newState = reducer(stubInitialState, {
             type: authConstants.GET_NOTI_SUCCESS,
-            target: [{
-                id: 1, actor: { id: 1 }, action_object: { id: 1 }, verb: "liked",
-            }],
+            target: {
+                notifications: [{
+                    id: 1, actor: { id: 1 }, action_object: { id: 1 }, verb: "liked",
+                }],
+                page_number: 1,
+                total_count: 1,
+                is_finished: true,
+            },
         });
-        expect(newState.getNotiStatus).toEqual(notiStatus.SUCCESS);
-        expect(newState.notifications).toEqual([{
+        expect(newState.notifications.getStatus).toEqual(notiStatus.SUCCESS);
+        expect(newState.notifications.notifications).toEqual([{
             id: 1, actor: { id: 1 }, action_object: { id: 1 }, verb: "liked",
         }]);
     });
@@ -188,7 +198,7 @@ describe("Auth reducer", () => {
             type: authConstants.GET_NOTI_FAILURE,
             target: stubError,
         });
-        expect(newState.getNotiStatus).toEqual(notiStatus.FAILURE);
+        expect(newState.notifications.getStatus).toEqual(notiStatus.FAILURE);
     });
 
 
@@ -197,7 +207,7 @@ describe("Auth reducer", () => {
             type: authConstants.READ_NOTI_SUCCESS,
             target: null,
         });
-        expect(newState.readNotiStatus).toEqual(notiStatus.SUCCESS);
+        expect(newState.notifications.readStatus).toEqual(notiStatus.SUCCESS);
     });
 
     it("should handle readNotification failure", () => {
@@ -205,7 +215,7 @@ describe("Auth reducer", () => {
             type: authConstants.READ_NOTI_FAILURE,
             target: stubError,
         });
-        expect(newState.readNotiStatus).toEqual(notiStatus.FAILURE);
+        expect(newState.notifications.readStatus).toEqual(notiStatus.FAILURE);
     });
 
     it("should handle getSubscription", () => {

--- a/frontend/src/store/reducers/collection/collection.js
+++ b/frontend/src/store/reducers/collection/collection.js
@@ -370,6 +370,7 @@ const reducer = (state = initialState, action) => {
                 list: action.target.collections,
                 pageNum: action.target.pageNum,
                 finished: action.target.finished,
+                totalCount: action.target.totalCount,
             },
         };
     case collectionConstants.SEARCH_COLLECTION_FAILURE:
@@ -381,6 +382,7 @@ const reducer = (state = initialState, action) => {
                 error: action.target,
                 pageNum: 0,
                 finished: false,
+                totalCount: 0,
             },
         };
     case collectionConstants.GET_COLLECTION_LIKE_SUCCESS:

--- a/frontend/src/store/reducers/review/review.js
+++ b/frontend/src/store/reducers/review/review.js
@@ -13,6 +13,7 @@ const initialState = {
         error: null,
         pageNum: 0,
         finished: true,
+        totalCount: 0,
     },
     edit: {
         status: reviewStatus.NONE,
@@ -102,6 +103,7 @@ const ReviewReducer = (state = initialState, action) => {
                 list: action.target.reviews,
                 pageNum: action.target.page_number,
                 finished: action.target.is_finished,
+                totalCount: action.target.total_count,
             },
         };
     case reviewConstants.GET_REVIEW:

--- a/frontend/src/store/reducers/user/user.js
+++ b/frontend/src/store/reducers/user/user.js
@@ -23,6 +23,7 @@ const initialState = {
         pageNum: 0,
         finished: true,
         error: null,
+        totalCount: 0,
     },
     followCount: 0,
     unfollowCount: 0,
@@ -136,6 +137,7 @@ const UserReducer = (state = initialState, action) => {
                 users: action.target.users,
                 pageNum: action.target.pageNum,
                 finished: action.target.finished,
+                totalCount: action.target.totalCount,
             },
         };
     case userConstants.SEARCH_USER_FAILURE:
@@ -147,6 +149,7 @@ const UserReducer = (state = initialState, action) => {
                 pageNum: 0,
                 finished: false,
                 error: action.target,
+                totalCount: 0,
             },
         };
     default:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astroid==2.2.5
-Django==2.2.8
+Django==2.2.6
 isort==4.3.21
 mccabe==0.6.1
 pylint==2.3.1


### PR DESCRIPTION
Related Issue: #148, #172 
This PR will resolve #148 and resolve #172 issues.



# Major changes
## 1. Notification Scroll Pagination
Now, you can get all notifications by just scrolling the dropdown menu.
<img width="1050" alt="스크린샷 2019-12-15 02 02 26" src="https://user-images.githubusercontent.com/35535636/70851927-fd54fd80-1ede-11ea-96d3-f910b8ffa4c7.png">

## 2. True count of notifications.
As you can see in the screenshot above.

## 3. True count of reviews on ProfileDetail
Yes. No more ambiguous '+' signs. 
<img width="1043" alt="스크린샷 2019-12-15 02 03 18" src="https://user-images.githubusercontent.com/35535636/70851934-1198fa80-1edf-11ea-932b-ae40e05061ab.png">

## 4. True count of collections/users on SearchResult.
Same.
<img width="1060" alt="스크린샷 2019-12-15 02 03 47" src="https://user-images.githubusercontent.com/35535636/70851936-22e20700-1edf-11ea-8ce8-04832d41345b.png">

## 5. Downgraded Django
I downgraded Django to 2.2.6 because suddenly Travis says like below.
```
Could not find a version that satisfies the requirement Django==2.2.8 (from -r requirements.txt (line 2)) (from versions: 1.1.3, 1.1.4, 1.2, 1.2.1, 1.2.2, 1.2.3, 1.2.4, 1.2.5, 1.2.6, 1.2.7, 1.3, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.3.5, 1.3.6, 1.3.7, 1.4, 1.4.1, 1.4.2, 1.4.3, 1.4.4, 1.4.5, 1.4.6, 1.4.7, 1.4.8, 1.4.9, 1.4.10, 1.4.11, 1.4.12, 1.4.13, 1.4.14, 1.4.15, 1.4.16, 1.4.17, 1.4.18, 1.4.19, 1.4.20, 1.4.21, 1.4.22, 1.5, 1.5.1, 1.5.2, 1.5.3, 1.5.4, 1.5.5, 1.5.6, 1.5.7, 1.5.8, 1.5.9, 1.5.10, 1.5.11, 1.5.12, 1.6, 1.6.1, 1.6.2, 1.6.3, 1.6.4, 1.6.5, 1.6.6, 1.6.7, 1.6.8, 1.6.9, 1.6.10, 1.6.11, 1.7, 1.7.1, 1.7.2, 1.7.3, 1.7.4, 1.7.5, 1.7.6, 1.7.7, 1.7.8, 1.7.9, 1.7.10, 1.7.11, 1.8a1, 1.8b1, 1.8b2, 1.8rc1, 1.8, 1.8.1, 1.8.2, 1.8.3, 1.8.4, 1.8.5, 1.8.6, 1.8.7, 1.8.8, 1.8.9, 1.8.10, 1.8.11, 1.8.12, 1.8.13, 1.8.14, 1.8.15, 1.8.16, 1.8.17, 1.8.18, 1.8.19, 1.9a1, 1.9b1, 1.9rc1, 1.9rc2, 1.9, 1.9.1, 1.9.2, 1.9.3, 1.9.4, 1.9.5, 1.9.6, 1.9.7, 1.9.8, 1.9.9, 1.9.10, 1.9.11, 1.9.12, 1.9.13, 1.10a1, 1.10b1, 1.10rc1, 1.10, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.10.5, 1.10.6, 1.10.7, 1.10.8, 1.11a1, 1.11b1, 1.11rc1, 1.11, 1.11.1, 1.11.2, 1.11.3, 1.11.4, 1.11.5, 1.11.6, 1.11.7, 1.11.8, 1.11.9, 1.11.10, 1.11.11, 1.11.12, 1.11.13, 1.11.14, 1.11.15, 1.11.16, 1.11.17, 1.11.18, 1.11.20, 1.11.21, 1.11.22, 1.11.23, 1.11.24, 1.11.25, 2.0a1, 2.0b1, 2.0rc1, 2.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.0.8, 2.0.9, 2.0.10, 2.0.12, 2.0.13, 2.1a1, 2.1b1, 2.1rc1, 2.1, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.1.5, 2.1.7, 2.1.8, 2.1.9, 2.1.10, 2.1.11, 2.1.12, 2.1.13, 2.2a1, 2.2b1, 2.2rc1, 2.2, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 3.0a1)
472No matching distribution found for Django==2.2.8
```


# Minor changes
## 1. The count of papers is removed.




### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [ ] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
