### PR TITLE
Redis Cache for Searching Papers

### DIFF
--- a/backend/PapersFeed_backend/settings.py
+++ b/backend/PapersFeed_backend/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 import logging
 
-logging.getLogger().setLevel(logging.WARNING)
+logging.getLogger().setLevel(logging.ERROR)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -89,6 +89,15 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://localhost:6379/1',
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+        }
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/backend/PapersFeed_backend/settings.py
+++ b/backend/PapersFeed_backend/settings.py
@@ -93,7 +93,7 @@ CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://localhost:6379/1',
-        'TIMEOUT': None,
+        'TIMEOUT': 604800,  # 7 days
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
             'MAX_ENTRIES': 1000,

--- a/backend/PapersFeed_backend/settings.py
+++ b/backend/PapersFeed_backend/settings.py
@@ -93,8 +93,10 @@ CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': 'redis://localhost:6379/1',
+        'TIMEOUT': None,
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            'MAX_ENTRIES': 1000,
         }
     }
 }

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -174,7 +174,7 @@ def get_review_user(args):
             constants.TOTAL_COUNT: total_count}
 
 
-@cache_page(60 * 15)
+@cache_page(None)
 @view_exceptions_handler
 def get_paper_search(request):
     """Get Paper Search"""

--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -3,9 +3,10 @@
 
 # Internal Modules
 import json
+from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-from papersfeed.utils.base_utils import view_exceptions_handler
+from papersfeed.utils.base_utils import view_exceptions_handler, check_session
 from papersfeed.utils.papers import utils as papers_utils
 from papersfeed.utils.users import utils as users_utils
 from papersfeed.utils.collections import utils as collections_utils
@@ -173,8 +174,13 @@ def get_review_user(args):
             constants.TOTAL_COUNT: total_count}
 
 
-def get_paper_search(args):
+@cache_page(60 * 15)
+@view_exceptions_handler
+def get_paper_search(request):
     """Get Paper Search"""
+    args = request.GET.dict()
+    args[constants.REQUEST] = request
+    check_session(args, request)
     papers, page_number, is_finished = papers_utils.select_paper_search(args)
     return {constants.PAPERS: papers,
             constants.PAGE_NUMBER: page_number,

--- a/backend/papersfeed/utils/base_utils.py
+++ b/backend/papersfeed/utils/base_utils.py
@@ -4,8 +4,10 @@ import logging
 import traceback
 from django.http import JsonResponse
 from django.core.paginator import Paginator
+from django.core.exceptions import ObjectDoesNotExist
 
 from papersfeed import constants
+from papersfeed.models.users.user import User
 
 
 class ApiError(Exception):
@@ -32,6 +34,21 @@ def get_results_from_queryset(queryset, count, page_num=0):
         return pages.get_page(page_num)
 
     return results
+
+def check_session(args, request):
+    """Check Session"""
+    # User Id
+    user_id = request.session.get(constants.ID, None)
+    if not user_id:
+        raise ApiError(constants.AUTH_ERROR)
+
+    try:
+        # Get User By Id
+        user = User.objects.get(id=user_id)
+    except ObjectDoesNotExist:
+        raise ApiError(constants.AUTH_ERROR)
+    else:
+        args[constants.USER] = user
 
 
 def view_exceptions_handler(func):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ django-notifications-hq==1.5.0
 xmltodict==0.12.0
 celery==4.3.0
 redis==3.3.11
+django-redis==4.11.0


### PR DESCRIPTION
Related Issue: #210 
This PR will resolve #210.


# Major changes
I applied caching to Django for `GET /api/paper/search`.
When users search papers, the results are cached for 7 days, unless cached keys reach `MAX_ENTRIES`(1000). One result(one page of results) takes up 2 entries.

I checked this system make searching papers which were searched before by someone not really fast.

# Minor changes
Lowered the logging level to `ERROR`.

### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
