### PR TITLE
Using Low-level Cache for Searching papers

### DIFF
--- a/backend/papersfeed/apis.py
+++ b/backend/papersfeed/apis.py
@@ -3,7 +3,6 @@
 
 # Internal Modules
 import json
-from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_exempt
 
 from papersfeed.utils.base_utils import view_exceptions_handler, check_session
@@ -174,7 +173,7 @@ def get_review_user(args):
             constants.TOTAL_COUNT: total_count}
 
 
-@cache_page(None)
+# @cache_page(None)
 @view_exceptions_handler
 def get_paper_search(request):
     """Get Paper Search"""

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -175,7 +175,7 @@ def select_paper_search(args):
             is_finished = False
 
         # Cache set
-        cache.set(cache_key, (result_ids, paper_ids, external, is_finished))
+        cache.set(cache_key, (result_ids, paper_ids, external, is_finished), timeout=None)
         logging.info("CACHE SET: %s", cache_key)
 
     # Papers - Sometimes, there can be duplicated ids in result_ids. Thus, len(papers) < len(result_ids) is possible.

--- a/backend/papersfeed/utils/papers/utils.py
+++ b/backend/papersfeed/utils/papers/utils.py
@@ -7,6 +7,7 @@ import json
 import logging
 import requests
 import xmltodict
+from django.core.cache import cache
 from django.db.models import Q, Exists, OuterRef, Count, Case, When
 
 from papersfeed import constants
@@ -101,67 +102,81 @@ def select_paper_search(args):
     # Page Number
     page_number = 1 if constants.PAGE_NUMBER not in args else int(args[constants.PAGE_NUMBER])
 
-    paper_ids = {
-        'papersfeed': [], # only used when all external search fails
-        'arxiv': [],
-        'crossref': [],
-    }
-    is_finished_dict = {
-        'arxiv': False,
-        'crossref': False,
-    }
+    # Check cache
+    cache_key = keyword + '_' + str(page_number)
+    cache_result = cache.get(cache_key)
 
-    future_to_source = {}
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        future_to_source[executor.submit(exploit_arxiv, keyword, page_number)] = 'arxiv'
-        future_to_source[executor.submit(exploit_crossref, keyword, page_number)] = 'crossref'
-        for future in concurrent.futures.as_completed(future_to_source):
-            source = future_to_source[future]
-            try:
-                paper_ids[source], is_finished_dict[source] = future.result()
-            except Exception as exc: # pylint: disable=broad-except
-                logging.warning("[%s] generated an exception: %s", source, exc)
+    if cache_result:
+        logging.info("CACHE HIT: %s", cache_key)
+        result_ids, paper_ids, external, is_finished = cache_result
 
-    external = True
-    # if there are both results (len <= SEARCH_RESULT * 2)
-    if paper_ids['arxiv'] and paper_ids['crossref']:
-        result_ids = paper_ids['arxiv'] + paper_ids['crossref']
-        is_finished = is_finished_dict['arxiv'] and is_finished_dict['crossref']
-
-    # if only there are results of Crossref (len <= SEARCH_COUNT)
-    elif not paper_ids['arxiv'] and paper_ids['crossref']:
-        result_ids = paper_ids['crossref']
-        is_finished = is_finished_dict['crossref']
-
-    # if only there are results of arXiv (len <= SEARCH_COUNT)
-    elif not paper_ids['crossref'] and paper_ids['arxiv']:
-        result_ids = paper_ids['arxiv']
-        is_finished = is_finished_dict['arxiv']
-
-    # if cannot get any results from external sources
     else:
-        external = False
-        logging.info("[naive-search] Searching in PapersFeed DB")
+        logging.info("CACHE MISS: %s", cache_key)
+        paper_ids = {
+            'papersfeed': [], # only used when all external search fails
+            'arxiv': [],
+            'crossref': [],
+        }
+        is_finished_dict = {
+            'arxiv': False,
+            'crossref': False,
+        }
 
-        # Papers Queryset
-        queryset = Paper.objects.filter(Q(title__icontains=keyword) | Q(abstract__icontains=keyword)) \
-            .values_list('id', 'abstract')
+        future_to_source = {}
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_to_source[executor.submit(exploit_arxiv, keyword, page_number)] = 'arxiv'
+            future_to_source[executor.submit(exploit_crossref, keyword, page_number)] = 'crossref'
+            for future in concurrent.futures.as_completed(future_to_source):
+                source = future_to_source[future]
+                try:
+                    paper_ids[source], is_finished_dict[source] = future.result()
+                except Exception as exc: # pylint: disable=broad-except
+                    logging.warning("[%s] generated an exception: %s", source, exc)
 
-        # Check if the papers have keywords. If not, try extracting keywords this time
-        abstracts = {}
-        for paper_id, abstract in queryset:
-            paper_ids['papersfeed'].append(paper_id)
+        external = True
+        # if there are both results (len <= SEARCH_RESULT * 2)
+        if paper_ids['arxiv'] and paper_ids['crossref']:
+            result_ids = paper_ids['arxiv'] + paper_ids['crossref']
+            is_finished = is_finished_dict['arxiv'] and is_finished_dict['crossref']
 
-            if not PaperKeyword.objects.filter(paper_id=paper_id).exists():
-                abstracts[paper_id] = abstract
+        # if only there are results of Crossref (len <= SEARCH_COUNT)
+        elif not paper_ids['arxiv'] and paper_ids['crossref']:
+            result_ids = paper_ids['crossref']
+            is_finished = is_finished_dict['crossref']
 
-        if abstracts:
-            __extract_keywords_from_abstract(abstracts)
+        # if only there are results of arXiv (len <= SEARCH_COUNT)
+        elif not paper_ids['crossref'] and paper_ids['arxiv']:
+            result_ids = paper_ids['arxiv']
+            is_finished = is_finished_dict['arxiv']
 
-        # Paper Ids
-        result_ids = get_results_from_queryset(paper_ids['papersfeed'], SEARCH_COUNT, page_number)
-        # is_finished (tentative)
-        is_finished = False
+        # if cannot get any results from external sources
+        else:
+            external = False
+            logging.info("[naive-search] Searching in PapersFeed DB")
+
+            # Papers Queryset
+            queryset = Paper.objects.filter(Q(title__icontains=keyword) | Q(abstract__icontains=keyword)) \
+                .values_list('id', 'abstract')
+
+            # Check if the papers have keywords. If not, try extracting keywords this time
+            abstracts = {}
+            for paper_id, abstract in queryset:
+                paper_ids['papersfeed'].append(paper_id)
+
+                if not PaperKeyword.objects.filter(paper_id=paper_id).exists():
+                    abstracts[paper_id] = abstract
+
+            if abstracts:
+                __extract_keywords_from_abstract(abstracts)
+
+            # Paper Ids
+            result_ids = get_results_from_queryset(paper_ids['papersfeed'], SEARCH_COUNT, page_number)
+            # is_finished (tentative)
+            is_finished = False
+
+        # Cache set
+        cache.set(cache_key, (result_ids, paper_ids, external, is_finished))
+        logging.info("CACHE SET: %s", cache_key)
 
     # Papers - Sometimes, there can be duplicated ids in result_ids. Thus, len(papers) < len(result_ids) is possible.
     papers, _, is_finished = __get_papers_search(result_ids, request_user, paper_ids, external, is_finished)


### PR DESCRIPTION
Related Issue: #210 
This PR solve a problem of #211 PR.


# Major changes
There was a problem in the per-view cache #211 PR.
Because the results includes counts of likes and reviews, the results in the time when they were first searched remain even after actual data are changed.

So I solved this problem using low-level cache. Please refer to [here](https://docs.djangoproject.com/en/3.0/topics/cache/#the-low-level-cache-api) for more information.

You can see messages like 'CACHE MISS -> CACHE SET' or 'CACHE HIT' in logs below. I use `'searchword' + '_' + 'page_number'` as cache keys.

```
INFO:root:CACHE MISS: nuclear_1
INFO:root:[arXiv API] searching (0~19)
INFO:root:[Crossref API] searching (0~19)
[16/Dec/2019 13:12:11] “GET /api/user/search?text=nuclear&page_number=1 HTTP/1.1” 200 70
[16/Dec/2019 13:12:11] “GET /api/collection/search?text=nuclear&page_number=1 HTTP/1.1" 200 76
INFO:root:[arXiv API] response latency: 1.1720712184906006
INFO:root:[Crossref API] response latency: 1.330610752105713
INFO:root:CACHE SET: nuclear_1
[16/Dec/2019 13:12:13] “GET /api/paper/search?text=nuclear HTTP/1.1” 200 49698
INFO:root:CACHE MISS: nuclear_2
INFO:root:[arXiv API] searching (20~39)
INFO:root:[Crossref API] searching (20~39)
INFO:root:[arXiv API] response latency: 1.1979773044586182
INFO:root:[Crossref API] response latency: 1.2289621829986572
INFO:root:CACHE SET: nuclear_2
[16/Dec/2019 13:12:16] “GET /api/paper/search?text=nuclear&page_number=2 HTTP/1.1" 200 27242
INFO:root:CACHE MISS: nuclear_3
INFO:root:[arXiv API] searching (40~59)
INFO:root:[Crossref API] searching (40~59)
INFO:root:[Crossref API] response latency: 0.9356091022491455
INFO:root:[arXiv API] response latency: 0.9811587333679199
INFO:root:CACHE SET: nuclear_3
[16/Dec/2019 13:12:19] “GET /api/paper/search?text=nuclear&page_number=3 HTTP/1.1” 200 49954
[16/Dec/2019 13:12:21] “GET /api/user/me HTTP/1.1" 200 235
[16/Dec/2019 13:12:21] “GET /api/notification?page_number=0 HTTP/1.1” 200 1733
[16/Dec/2019 13:12:21] “GET /api/subscription HTTP/1.1" 200 30425
[16/Dec/2019 13:12:21] “GET /api/recommendation HTTP/1.1” 200 62
[16/Dec/2019 13:12:24] “DELETE /api/session HTTP/1.1" 200 2
[16/Dec/2019 13:12:30] “GET /api/session?email=girin@snu.ac.kr&password=girin HTTP/1.1” 200 137
[16/Dec/2019 13:12:30] “GET /api/notification?page_number=0 HTTP/1.1" 200 1918
[16/Dec/2019 13:12:30] “GET /api/subscription HTTP/1.1” 200 54421
[16/Dec/2019 13:12:30] “GET /api/recommendation HTTP/1.1" 200 62
INFO:root:CACHE HIT: nuclear_1
[16/Dec/2019 13:12:33] “GET /api/user/search?text=nuclear&page_number=1 HTTP/1.1” 200 70
[16/Dec/2019 13:12:33] “GET /api/collection/search?text=nuclear&page_number=1 HTTP/1.1" 200 76
[16/Dec/2019 13:12:33] “GET /api/paper/search?text=nuclear HTTP/1.1” 200 49698
INFO:root:CACHE HIT: nuclear_2
[16/Dec/2019 13:12:35] “GET /api/paper/search?text=nuclear&page_number=2 HTTP/1.1" 200 44260
INFO:root:CACHE HIT: nuclear_3
[16/Dec/2019 13:12:38] “GET /api/paper/search?text=nuclear&page_number=3 HTTP/1.1” 200 49954
INFO:root:CACHE MISS: nuclear_4
INFO:root:[arXiv API] searching (60~79)
INFO:root:[Crossref API] searching (60~79)
INFO:root:[arXiv API] response latency: 1.0516901016235352
INFO:root:[Crossref API] response latency: 1.2111213207244873
INFO:root:CACHE SET: nuclear_4

```

# Minor changes





### Checklist
This pull request...
- [x] has preceding issues related with it (if resolves some issues, metions them with 'resolve')
- [x] doesn't include too many changes (you should focus on the specific feature in a PR)
- [x] elaborately explains what feature is added, which part is fixed or improved
- [x] has step by step instructions for collaborators, if needed
- [x] has attached screenshots, if appropriate

My codes...
- [x] include enough tests for added and changed parts
- [x] pass all the new and existing tests
- [x] include appropriate comments
- [x] don't introduce unnecessary warnings
